### PR TITLE
ENHANCEMENT: Better EADDRONUSE Error Handling on Startup

### DIFF
--- a/build/brunch-server.js
+++ b/build/brunch-server.js
@@ -8,8 +8,9 @@
 const express = require('express');
 const app     = express();
 
-/// SERVER STATIC FILES ///////////////////////////////////////////////////////
+/// MIDDLEWARE ////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// serve static files
     app.use( express.static(__dirname + '/public') );
 
 /// WEBSERVICE STUB ///////////////////////////////////////////////////////////
@@ -26,7 +27,22 @@ const app     = express();
       app.listen(config.port, function () {
         console.log(`APP SERVER LISTENING on PORT ${config.port}`);
         callback();
-      });
+      })
+      .on('error', function(err) {
+        let errstring = `### NETCREATE STARTUP ERROR: '${err.errno}'\n`;
+        switch (err.errno) {
+          case 'EADDRINUSE':
+            errstring += `Another program is already using port ${config.port}.\n`;
+            errstring += `Go to "http://localhost:${config.port}" to check if NetCreate is already running.\n\n`;
+            errstring += `Still broken? See https://github.com/daveseah/netcreate-2018/issues/4\n`;
+            break;
+          default:
+            errstring += `${err}`;
+            console.log(err);
+        }
+        console.log(`\n\n${errstring}\n### PROGRAM STOP\n`);
+        process.exit(err.errno);
+      });;
 
       // Return the app; it has the `close()` method, which would be ran when
       // Brunch server is terminated. This is a requirement.


### PR DESCRIPTION
DESCRIPTION (SEE ISSUE #4)

The NetCreate custom Express server `brunch-server.js` will complain with  "address in use" error when another program is already using port 3000. The error text is not helpful to non-technical users.

Now the help text IS useful, and provides instructions on what to do about it.

TESTING

* open a terminal window and `cd` to the NetCreate `build` directory
* run NetCreate with `npm run dev`
* confirm it starts with no errors
* leave NetCreate running and **open a second terminal window**
* in the second window, `npm run dev` again
* confirm that the new EADDRINUSE error message shows and makes sense