### PR TITLE
Feature: Swap Source and Target Nodes on Edges

### DIFF
--- a/build/app/view/netcreate/components/EdgeEditor.jsx
+++ b/build/app/view/netcreate/components/EdgeEditor.jsx
@@ -449,7 +449,7 @@ class EdgeEditor extends UNISYS.Component {
 
         }
         // pass currentAutoComplete back to search
-        this.Call('AUTOCOMPLETE_SELECT',{id:'search'});
+        this.AppCall('AUTOCOMPLETE_SELECT',{id:'search'});
         this.setState({ isExpanded: true });
       } else {
         // No node selected, so we don't need to do anything


### PR DESCRIPTION
When entering a new edge, sometimes it's useful to be able to swap the source and target nodes if an edge relationship goes in a particular direction.  This is especially true if you're adding multiple edges.

There is now a new "up arrow/down arrow" button that will swap the source and target while you are editing a node.

There were a few refinements in our implementation that needed to be addressed in order to do this:

* We had modeless edge node selection (e.g. you could just type in the target field), which is nice for flexibility, but doesn't distinguish between a search term and a found node.

* This isn't a problem if you search and select a target node from the suggestions list.

* However, this results in being able to Save an edge with a partial search term if you hadn't selected anything from the list.

* So we needed to add data validation as well.

* We also needed to be able to designate when a target node has been selected vs. when it is only just a search/suggestion list.


## Edit Target Mode

### New Feature 1: Target Nodes toggle between Editable and Valid states

Now during an edge edit, after you select a target node, the target field is disabled, indicating that you've successfully selected a target node.


### New Feature 2: "Change Target" button to edit Target Nodes.

However, this raises a need for new user functionality: if you select the wrong node you also need to be able to change it.  In our previous implementation, we didn't allow editing of the target node once the edge had been saved, which was fine because you could edit it while you were working on it. However, now if you accidentally select the wrong target, you'd have to delete the whole edge. This seems too restrictive.

So in addition, there is now a "Change Target" button that allows you to edit the target node after selection.  A nice side effect of this is now you can always change the target.

However, if the target node is the parent node (the main node selected in the Node Selector form), then we shouldn't allow the user to edit that.  So the "Change Target" is only shown if the target is NOT the Node Selector node.


### New Feature 3: "Change Source"

There's an additional use case that we need to address: If you swap the source and target, the target node becomes the main selected Node that is in the NodeSelector form.  And when you click "Change Target" you end up changing the link to the parent Node to point to another node.  And, after you make this change, that edge should technically disappear from the Edges view.  This is awkward.

This is also a problem when you edit an edge where the main Node Selector node is the target of the edge.

One solution might be to disallow "Change Target" if the parent selected Node is the target node.  If you then want to change the edge link to the selected Node as target, you'd have to select the source node first, then edit that edge.  While simpler to implement, it makes editing edges difficult.

Our solution was to change the "Change Target" button to "Change Source", allowing the user to change the source instead.  This way the edge can still appear in the list of edges related to the node in the NodeSelector.  There is now also an "Change Source" button that allows you to change the source if you're editing the edge.


# TO TEST

1. Check out `dev-bl/swap-source-and-target` branch.
2. `npm run dev`
3. Load an existing database, or create a new one with two nodes with links going in both directions.
4. Select a node

## TEST SWAP
5. Select an edge where the node is the source (the edge should read "this -> OtherNode".
6. Click "Edit Edge"
7.  You should see a swap button with up/down arrows and a "Change Target" button.
8. Click on the swap button
9. The selected node should now be the target.
10. Click "Save" to save the change.
11. Review the node to make sure the change took place.
12. Reload the graph to make sure the change was saved.

## TEST CHANGE TARGET
5. Select an edge where the node is the source (the edge should read "this -> OtherNode".
6. Click "Edit Edge"
7.  You should see a swap button with up/down arrows and a "Change Target" button.
8. Click on the "Change Target" button
9. You should be able to search for another target node, or click on the graph to select a target node.
10. When you've selected a target node, the Target Node field should become disabled (light blue, can't type in it).
11. Click on "Change Target" again to pick a different target.
12. Click "Save" to save the change.
13. Review the node to make sure the change took place.
14. Reload the graph to make sure the change was saved.

## TEST CHANGE SOURCE
5. Select an edge where the node is the source (the edge should read "this -> OtherNode".
6. Click "Edit Edge"
7.  You should see a "Change Source" button next to the source, and just the swap button next to the target.
8. Click on the "Change Source" button
9. You should be able to search for another source node, or click on the graph to select a source node.
10. When you've selected a source node, the Source Node field should become disabled (light blue, can't type in it).
11. Click on "Change Source" again to pick a different source.
12. Click "Save" to save the change.
13. Review the node to make sure the change took place.
14. Reload the graph to make sure the change was saved.
