### PR TITLE
Fix Network Edge Updates Clobbering Edge Edits

### DIFF
--- a/build/app/view/netcreate/components/EdgeEditor.jsx
+++ b/build/app/view/netcreate/components/EdgeEditor.jsx
@@ -365,6 +365,8 @@ class EdgeEditor extends UNISYS.Component {
           isEditable:           true
         });
 
+        this.AppCall('EDGEEDIT_LOCK', { edgeID: this.props.edgeID });
+
       } else {
 
         // LOAD EXISTING EDGE
@@ -508,6 +510,7 @@ class EdgeEditor extends UNISYS.Component {
           isEditable: true
         });
       }
+      this.AppCall('EDGEEDIT_LOCK', { edgeID: this.props.edgeID });
 
     } // handleEdgeEdit
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -537,8 +540,10 @@ class EdgeEditor extends UNISYS.Component {
         if (this.state.isEditable) {
           this.loadSourceAndTarget();
           this.setState({ isEditable: false, targetIsEditable: false });
+          this.AppCall('EDGEEDIT_UNLOCK', { edgeID: this.props.edgeID });
           this.AppCall('AUTOCOMPLETE_SELECT',{id:'search'});
         }
+
       } else {
         // expand, but don't set the autocomplete field, since we're not editing
         this.setState({ isExpanded: true });
@@ -548,12 +553,14 @@ class EdgeEditor extends UNISYS.Component {
 /*/
 /*/ onDeleteButtonClick () {
       this.clearForm();
+      this.AppCall('EDGEEDIT_UNLOCK', { edgeID: this.props.edgeID });
       this.AppCall('DB_UPDATE',{edgeID:this.props.edgeID});
     }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/
 /*/ onEditButtonClick () {
       this.setState({ isEditable: true });
+      this.AppCall('EDGEEDIT_LOCK', { edgeID: this.props.edgeID });
 
       // Don't allow editing of the source or target fields.
       // If you want to change the edge, delete this one and create a new one.
@@ -662,6 +669,7 @@ class EdgeEditor extends UNISYS.Component {
       }
       if (DBG) console.group('EdgeEntry.onSubmit submitting',edge)
 
+      this.AppCall('EDGEEDIT_UNLOCK', { edgeID: this.props.edgeID });
       // pass currentAutoComplete back to nodeselector
       this.AppCall('AUTOCOMPLETE_SELECT',{id:'search'});
       this.setState({ isEditable: false, sourceIsEditable: false, targetIsEditable: false });


### PR DESCRIPTION
From Issue #54:

When you're in the middle of adding a new edge, if someone on the network also adds a new edge to the node you have currently selected, the edge update event will clobber your current edits.

* If you haven't selected a "Target" node, the "Source" node will be inserted as a target.
* If you HAVE selected a "Target" node, your Edge edit form will be closed.


To replicate:

On first computer: select a node, e.g. "Alexander"
On first computer: click "Add Edge"
On SECOND computer: select a node, e.g. "Alexander"
On SECOND computer: click "Add Edge"
On SECOND computer: select a target node
On SECOND computer: click "Save"
Notice on the first computer, the "Target" node is now set to Alexander.
So the problem is how we're handling network edge updates.

---

# The Fix

We added a lock flag, so if you're editing an edge, if a network edge update comes in, the NodeSelector will not update the list of edges until you're done editing.

The fix was somewhat complicated as the EdgeEditor form elements are loaded by NodeSelector, so we had to establish communication between the EdgeEditor and the NodeSelector so that NodeSelector would know when to ignore edge updates.

NOTE This does not fix an instance where two might be editing the same edge at the same time.

# To Test

Use the replication sequence above.
