### PR TITLE
AutoComplete: Select node onBlur

### DIFF
--- a/build/app/view/netcreate/components/AutoComplete.jsx
+++ b/build/app/view/netcreate/components/AutoComplete.jsx
@@ -169,6 +169,7 @@ class AutoComplete extends UNISYS.Component {
       this.onSuggestionSelected        = this.onSuggestionSelected.bind(this);
       this.onSuggestionHighlighted     = this.onSuggestionHighlighted.bind(this);
       this.shouldRenderSuggestions     = this.shouldRenderSuggestions.bind(this);
+      this.onBlur                      = this.onBlur.bind(this);
 
       // NOTE: do this AFTER you have used bind() on the class method
       // otherwise the call will fail due to missing 'this' context
@@ -330,6 +331,13 @@ class AutoComplete extends UNISYS.Component {
 /*/ shouldRenderSuggestions (value) {
       return this.state.mode===MODE_ACTIVE;
     }
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/ The AutoComplete field has lost focus.
+    Check to see if it references a valid node, if so, select it
+/*/ onBlur (value) {
+      // User selected an existing node in the suggestion list
+      this.AppCall('SOURCE_SEARCH_AND_SELECT', { searchString: this.state.value } );
+    }
 
 /// REACT LIFECYCLE /////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -358,7 +366,8 @@ class AutoComplete extends UNISYS.Component {
       const inputProps = {
         placeholder : "Type node name...",
         value       : value,
-        onChange    : this.onInputChange
+        onChange    : this.onInputChange,
+        onBlur      : this.onBlur
       };
       let jsx;
 

--- a/build/app/view/netcreate/nc-logic.js
+++ b/build/app/view/netcreate/nc-logic.js
@@ -364,7 +364,8 @@ MOD.Hook("INITIALIZE", () => {
       SEE ALSO: AutoComplete.onSuggestionSelected() and
                 D3SimpleNetGraph._UpdateGraph click handler
   /*/
-  UDATA.HandleMessage("SOURCE_SELECT", function(data) {
+  UDATA.HandleMessage("SOURCE_SELECT", m_sourceSelect);
+  function m_sourceSelect (data) {
     if (DBG) console.log(PR, "SOURCE_SELECT got data", data);
 
     let { nodeLabels = [], nodeIDs = [] } = data;
@@ -413,7 +414,7 @@ MOD.Hook("INITIALIZE", () => {
 
     // Set the SELECTION state so that listeners such as NodeSelectors update themselves
     UDATA.SetAppState("SELECTION", newState);
-  });
+  }
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - inside hook
   /*/ SOURCE_SEARCH sets the current matching term as entered in an
@@ -430,6 +431,20 @@ MOD.Hook("INITIALIZE", () => {
     };
     // let SELECTION state listeners handle display updates
     UDATA.SetAppState("SEARCH", newState);
+  });
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - inside hook
+  /*/ SOURCE_SEARCH_AND_SELECT first searches for an exact mathcing node
+      and if found, selects it.
+      This is called by AutoComplete onBlur in case we need to make an
+      implicit selection.
+  /*/
+  UDATA.HandleMessage("SOURCE_SEARCH_AND_SELECT", function (data) {
+    let { searchString } = data;
+    let node = m_FindMatchingNodesByLabel(searchString).shift();
+    if (node && (node.label === searchString)) {
+      m_sourceSelect({ nodeIDs: [node.id] });
+    }
   });
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - inside hook


### PR DESCRIPTION
From Issue #58:

# The Problem

The AutoComplete field is designed to support a variety of input methods, including selecting by clicking on the graph and typing a partial name, viewing suggestions, and selecting a suggestion. This generally works well when it's used in the Search field or the NodeSelector form.

When editing an edge, the AutoComplete field is also used to set the Source (and more commonly) the Target nodes. This generally works well when the user either clicks on a node on the graph to select it, or when using type-ahead to select a node -- they type a partial node name, then they click on the full name in the suggestion. This works because clicking on a suggested node triggers a SOURCE_SELECT event, where we can verify that the selected node is a valid node.

The problem occurs when the user types in the full name of the node and then hits Tab to go on to the next field. In this case, no event is triggered, so we never verify that the node name typed in is a valid node, and therefore we don't re-enable the "Save" button.

##  To replicate:

1. Select a node
2. Click "Add New Edge"
3. Type the name of another edge and hit "tab"
4. The "Save" button remains disabled because the system doesn't know we have selected a valid target node.


# The Solution

We use the onBlur event on the AutoComplete field to trigger a review of the current field value.  If the value in the AutoComplete field is an exact match with a node label, select the label.

## To Test

1. Select a node
2. Click "Add New Edge"
3. Type the full name of another edge and hit "tab"
4. The target node should be properly set (You'll see the "Switch Source/Target" button and the "Change Target" button appear).
5. The "Save" button should be enabled.

A few more points:
* You should test to make sure also that typing in an incomplete label or a non-matching label does not select a node.
* This is a case sensitive search: So typing "alexander" will not autoselect "Alexander" and the "Save" button will remain disabled.

This has the side effect of also allowing selection of a node via the Search field:
1. Click in the Search Field
2. Type in the complete name of a label, e.g. "alexander"
3. Hit tab
4. The "Alexander" node will be loaded in the NodeSelector form.