### PR TITLE
Network Editing Fixes

### DIFF
--- a/build/app/view/netcreate/components/EdgeEditor.jsx
+++ b/build/app/view/netcreate/components/EdgeEditor.jsx
@@ -434,7 +434,6 @@ class EdgeEditor extends UNISYS.Component {
 /*/ handleSelection ( data ) {
       if (DBG) console.log('EdgeEditor',this.props.edgeID,'got SELECTION data',data);
 
-  
       // If we're one of the edges that have been updated, and we're not currently being edited,
       // then update the data.
       // If we're not currently being edited, then if edges have been updated, update self
@@ -901,6 +900,22 @@ class EdgeEditor extends UNISYS.Component {
       if (DBG) console.log('EdgeEditor.componentDidMount!');
       this.loadSourceAndTarget();
       this.onStateChange_SESSION(this.AppState('SESSION'));
+    }
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/ Release the lock if we're unmounting
+/*/ componentWillUnmount() {
+      if (DBG) console.log('EdgeEditor.componentWillUnMount!');
+      if (this.state.isEditable) {
+        this.NetCall('SRV_DBUNLOCKEDGE', { edgeID: this.state.formData.id })
+          .then((data) => {
+            if (data.NOP) {
+              if (DBG) console.log(`SERVER SAYS: ${data.NOP} ${data.INFO}`);
+            } else if (data.unlocked) {
+              if (DBG) console.log(`SERVER SAYS: unlock success! you have released Edge ${data.edgeID}`);
+              this.setState({ dbIsLocked: false });
+            }
+          });
+      }
     }
 } // class EdgeEditor
 


### PR DESCRIPTION
# IMPORTANT!

Please don't accept this pull request until after thorough testing!  I recommend keeping it separate until after the study.  Just use this branch (`dev-bl/network-fixes`) if these issues are likely to come up during the study.


# Description

QA testing revealed a few minor issues.

* Delete Node Bug -- Deleting a node would cause a js 'Cannot read property "find" of undefined' error.  EdgeEditor.handleSelect was trying to process a selection with no edge objects.

* Edges not Unlocked on unmount -- If you start to edit an edge, but then decide against it and just select another edge or node, the edge lock is never released.  Edge locks are now released when the EdgeEditor is unmounted.


# To Test

## Delete Node Bug

1. On the server computer, open the web console.
2. Select a node that has edges connected to it
3. Click the "Delete" button
4. The web console should no longer report a `Cannot read property "find" of undefined` error.


## Edge Unlock Bug
1. On any computer, select a node and then edge and click "Edit Edge"
2. Without clicking "Cancel" or "Save", select another node.
3. On any computer, select the original node and try to edit the same edge.  It should no longer be locked.  (If the fix didn't work, the edge would remain locked).


# Other Comments

We probably need to add something like an ncUnlockAll() web console command in case there are other db lock conditions that we didn't catch.