### PR TITLE
Add color key/legend

### DIFF
--- a/build/app/view/netcreate/components/NetGraph.jsx
+++ b/build/app/view/netcreate/components/NetGraph.jsx
@@ -103,7 +103,7 @@ class NetGraph extends UNISYS.Component {
             <Button outline onClick={this.onZoomOut} style={{ width: '35px' }}>-</Button>
           </div>
           <div style={{ position: 'absolute', bottom: '40px', marginLeft: '10px', marginBottom: '15px',fontSize: '10px' }}>
-            <span style={{ marginRight: '2em' }}></span>KEY:
+            <div style={{ display: 'inline-block', paddingRight: '2em' }}>KEY:</div>
             {nodeTypes.map((type, i) => (
               <div key={i} style={{ display:'inline-block', paddingRight:'2em', lineHeight:'10px' }}>
                 <div style={{ display:'inline-block',width:'10px',height:'8px',backgroundColor:type.color }}></div>


### PR DESCRIPTION
This implements a simple legend display across the bottom of the graph.

NOTES:
* The bottom of the screen seemed like the ideal place to put a legend because it doesn't take up much room and would cover less of the graph.
* The downside is that if you have a LOT of types or long labels, we would run out of room.
* The keys can wrap, though more than one line tends to get cut off by the accessible message.

![screenshot_431](https://user-images.githubusercontent.com/1403057/54064071-fe296800-41c5-11e9-89da-f2936e50c3d8.png)
