### PR TITLE
Version 1.3.1

### DIFF
--- a/build/app/assets/index.ejs
+++ b/build/app/assets/index.ejs
@@ -5,73 +5,71 @@
 		<!-- Required meta tags -->
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-		
-		<script src="netcreate-config.js"> 
-		// auto generated netcreate config script
-		</script>
-		<script src="https://kit.fontawesome.com/3f7330d0fa.js" crossorigin="anonymous"></script>
-	
-		<!-- Google Analytics -->
-		<script>
-		    let googlea = NC_CONFIG.googlea;
-		    if(googlea != "0"){
-
-				(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-				(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-				m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-				})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-				ga('create', 'UA-132368455-3', 'auto');
-				ga('send', 'pageview');
-			}
-		</script>
-		<!-- End Google Analytics -->
-
 		<style>
 			body {
 				min-height: 100%
 			}
-			.fas { display:inline; margin-right:2pt; }
-
-			
 		</style>
-			<script>
+		<link rel="stylesheet" href="/styles/netc-app.css" type="text/css">
+	</head>
+	<body>
+		<div id="app-container">
+			<div style="padding: 10px">Loading Net.Create...</div>
+		</div>
+		<script src="netcreate-config.js">
+				// auto generated netcreate config script
+		</script>
+		<script>
 			// NC_UNISYS are network parameters
 			if (window.NC_UNISYS) {
-				let err  = `**FATAL ERROR** NC_UNISYS already initialized.\n\n`;
+				let err = `**FATAL ERROR** NC_UNISYS already initialized.\n\n`;
 				err += `Take a screen shot with your phone and report the error!`
 				alert(err);
 				throw Error(err);
 			}
 			window.NC_UNISYS = {
-				client : {
-					ip       : '<%=ip%>',
-					ukey     : '<%=ukey%>'
+				client: {
+					ip: '<%=ip%>',
+					ukey: '<%=ukey%>'
 				},
-				server : {
-					hostname : '<%=hostname%>',
-					ip       : '<%=hostip%>',
-					ustart   : '<%=ustart%>'
+				server: {
+					hostname: '<%=hostname%>',
+					ip: '<%=hostip%>',
+					ustart: '<%=ustart%>'
 				},
-				socket : {
-					uaddr    : '<%=uaddr%>',
-					uport    : '<%=uport%>'
+				socket: {
+					uaddr: '<%=uaddr%>',
+					uport: '<%=uport%>'
 				}
 			};
 			//
 			window.NC_DBG = null; // {} or null
 			if (window.NC_DBG) {
 				Object.assign(window.NC_DBG, {
-					lifecycle : true
+					lifecycle: true
 				});
 			}
 		</script>
 		<script src="/scripts/netc-lib.js"></script>
 		<script src="/scripts/netc-app.js"></script>
-		<link rel="stylesheet" href="/styles/netc-app.css" type="text/css">
-	</head>
-	<body>
-		<div id="app-container"></div>
+		
+		<!-- Google Analytics -->
+		<script>
+			let googlea = NC_CONFIG.googlea;
+			if (googlea != "0") {
+
+				(function (i, s, o, g, r, a, m) {
+					i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+						(i[r].q = i[r].q || []).push(arguments)
+					}, i[r].l = 1 * new Date(); a = s.createElement(o),
+						m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+				})(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+
+				ga('create', 'UA-132368455-3', 'auto');
+				ga('send', 'pageview');
+			}
+		</script>
+		<!-- End Google Analytics -->
 		<script>
 			document.title += ` ${window.NC_CONFIG.dataset} @ ${window.NC_UNISYS.server.ip}`;
 			require("init");

--- a/build/app/assets/index.html
+++ b/build/app/assets/index.html
@@ -26,11 +26,6 @@
 
     </script>
     <!-- End Google Analytics -->
-    <style>
-			.fas { display:inline; margin-right:2pt; }
-
-    </style>
-    
     <script>
       // index.html is loaded only by standalone mode without a server
       // server-based operation uses index.ejs

--- a/build/app/init.jsx
+++ b/build/app/init.jsx
@@ -56,13 +56,21 @@ document.addEventListener("DOMContentLoaded", () => {
 /// UNISYS LIFECYCLE CLOSE EVENT //////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/ this custom event accesses post-run lifecycles defined for 'DOMContentLoaded'
+    `event` is originated by `comment-netmessage-class.GlobalOfflineMode
+    with a custom event message coming from client-network.m_ResetHearbeatTimer
+    This is so we can display an error to the user explaining the disconnect
 /*/
-document.addEventListener("UNISYSDisconnect", () => {
+document.addEventListener("UNISYSDisconnect", (event) => {
   console.log(
     "%cDISCONNECT %cUNISYSDisconnect. Closing UNISYS Lifecycle!",
     "color:blue",
     "color:auto"
   );
+  // This call will fail if the server is disconnected.
+  UNISYS.Log('Server disconnected with error', event);
+  // hack a local module for now
+  let UDATA = UNISYS.NewDataLink({});
+  UDATA.LocalCall('DISCONNECT', event);
   (async () => {
     await UNISYS.ServerDisconnect(); // UNISYS has dropped server
     console.log(

--- a/build/app/unisys/client-network.js
+++ b/build/app/unisys/client-network.js
@@ -178,9 +178,9 @@ function m_RespondToHeartbeat() {
 function m_ResetHearbeatTimer() {
   clearTimeout(m_hearbeat_timer);
   m_hearbeat_timer = setTimeout(function heartbeatStopped() {
-    if (DBG.handle) console.log(PR, 'heartbeat not received before time ran out -- YOURE DEAD!');
-    NetMessage.GlobalOfflineMode();
-  }, DEFS.SERVER_HEARTBEAT_INTERVAL + 1000);
+    if (DBG.handle) console.log(PR, 'ping heartbeat not received from server before time ran out -- YOURE DEAD!');
+    NetMessage.GlobalOfflineMode({ message: "Client Disconnected" });
+  }, DEFS.SERVER_HEARTBEAT_INTERVAL * 2);
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function m_HandleMessage(msgEvent) {

--- a/build/app/unisys/common-defs.js
+++ b/build/app/unisys/common-defs.js
@@ -10,7 +10,7 @@ const DBG         = true;
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 var   DEFS = {};
 
-DEFS.SERVER_HEARTBEAT_INTERVAL = 5000;
+DEFS.SERVER_HEARTBEAT_INTERVAL = 5000; // ms
 
 /// EXPORT MODULE DEFINITION //////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/build/app/unisys/common-netmessage-class.js
+++ b/build/app/unisys/common-netmessage-class.js
@@ -394,12 +394,23 @@ NetMessage.GlobalCleanup = function() {
 /*/ cleanup any allocated storage internally. This class operates both under the
     server and the client. This is a client feature.
 /*/
-NetMessage.GlobalOfflineMode = function() {
+NetMessage.GlobalOfflineMode = function(data) {
   m_mode = M_STANDALONE;
   if (m_netsocket) {
     console.warn(PR, "STANDALONE MODE: NetMessage disabling network");
     m_netsocket = null;
-    let event = new CustomEvent("UNISYSDisconnect", {});
+    // The disconnect is detected by client-network.js.
+    // If the disconnect is due to a missing ping heartbeat from the server
+    // (usually as a result of wifi/internet connection going down)
+    // it will include a data.message explaining 'Client Disconnect'.
+    // If there's no data.message, then this request came from
+    // either a standalone connect, a server "close" event,
+    // or a server "error" event.
+    let event = new CustomEvent("UNISYSDisconnect", {
+      detail: {
+        message: data ? data.message : "Server Disconnected"
+      }
+    });
     console.log("dispatching event to", document, event);
     document.dispatchEvent(event);
   }

--- a/build/app/unisys/server-network.js
+++ b/build/app/unisys/server-network.js
@@ -217,8 +217,9 @@ const SERVER_UADDR      = NetMessage.DefaultServerUADDR(); // is 'SVR_01'
       clearTimeout(m_pong_timer[uaddr]);
       m_pong_timer[uaddr] = setTimeout(function pongTimedOut() {
         if (DBG) console.log(PR, uaddr, 'pong not received before time ran out -- CONNECTION DEAD!');
+        LOGGER.Write(PR, uaddr, 'pong not received before time ran out -- CLIENT CONNECTION DEAD!');
         DB.RequestUnlock(uaddr);
-      }, DEFS.SERVER_HEARTBEAT_INTERVAL + 1000);
+      }, DEFS.SERVER_HEARTBEAT_INTERVAL * 2);
     }
 
 ///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/build/app/view/netcreate/components/EdgeEditor.jsx
+++ b/build/app/view/netcreate/components/EdgeEditor.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 /*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
 
   ## OVERVIEW
@@ -923,7 +924,11 @@ class EdgeEditor extends UNISYS.Component {
               <FormText onClick={this.onEdgeClick}><b>EDGE {formData.id}</b></FormText>
               <FormGroup row>
                 <Col sm={3} style={{hyphens: 'auto'}} className="pr-0">
-                  <Label for="source" className="tooltipAnchor small text-muted"><i className="fas fa-question-circle"></i>{edgePrompts.source.label}<span className="tooltiptext">{this.helpText(edgePrompts.source)}</span></Label>
+                  <Label for="source" className="tooltipAnchor small text-muted">
+                    <div className="badge">?</div>
+                    {edgePrompts.source.label}
+                    <span className="tooltiptext">{this.helpText(edgePrompts.source)}</span>
+                  </Label>
                 </Col>
                 <Col sm={9}>
                   <AutoComplete
@@ -944,7 +949,11 @@ class EdgeEditor extends UNISYS.Component {
               </FormGroup>
               <FormGroup row hidden={edgePrompts.type.hidden}>
                 <Col sm={3} style={{hyphens: 'auto'}} className="pr-0">
-                  <Label for="relationship" className="tooltipAnchor small text-muted"><i className="fas fa-question-circle"></i>{edgePrompts.type.label}<span className="tooltiptext">{this.helpText(edgePrompts.type)}</span></Label>
+                  <Label for="relationship" className="tooltipAnchor small text-muted">
+                    <div className="badge">?</div>
+                    {edgePrompts.type.label}
+                    <span className="tooltiptext">{this.helpText(edgePrompts.type)}</span>
+                  </Label>
                 </Col>
                 <Col sm={9}>
                   <Input type="select" name="relationship"
@@ -960,7 +969,11 @@ class EdgeEditor extends UNISYS.Component {
               </FormGroup>
               <FormGroup row>
                 <Col sm={3} style={{hyphens: 'auto'}} className="pr-0">
-                  <Label for="nodeLabel" className="tooltipAnchor small text-muted"><i className="fas fa-question-circle"></i>{edgePrompts.target.label}<span className="tooltiptext">{this.helpText(edgePrompts.target)}</span></Label>
+                  <Label for="nodeLabel" className="tooltipAnchor small text-muted">
+                    <div className="badge">?</div>
+                    {edgePrompts.target.label}
+                    <span className="tooltiptext">{this.helpText(edgePrompts.target)}</span>
+                  </Label>
                 </Col>
                 <Col sm={9}>
                   <AutoComplete
@@ -989,7 +1002,11 @@ class EdgeEditor extends UNISYS.Component {
               </FormGroup>
               <FormGroup row hidden={edgePrompts.category.hidden}>
                 <Col sm={3} style={{hyphens: 'auto'}} className="pr-0">
-                  <Label for="category" className="tooltipAnchor small text-muted"><i className="fas fa-question-circle"></i>{edgePrompts.category.label}<span className="tooltiptext">{this.helpText(edgePrompts.category)}</span></Label>
+                  <Label for="category" className="tooltipAnchor small text-muted">
+                    <div className="badge">?</div>
+                    {edgePrompts.category.label}
+                    <span className="tooltiptext">{this.helpText(edgePrompts.category)}</span>
+                  </Label>
                 </Col>
                 <Col sm={9}>
                   <Input type="text" name="category"
@@ -1000,7 +1017,11 @@ class EdgeEditor extends UNISYS.Component {
                 </Col>
               </FormGroup><FormGroup row hidden={edgePrompts.citation.hidden}>
                 <Col sm={3} style={{hyphens: 'auto'}} className="pr-0">
-                  <Label for="citation" className="tooltipAnchor small text-muted"><i className="fas fa-question-circle"></i>{edgePrompts.citation.label}<span className="tooltiptext">{this.helpText(edgePrompts.citation)}</span></Label>
+                  <Label for="citation" className="tooltipAnchor small text-muted">
+                    <div className="badge">?</div>
+                    {edgePrompts.citation.label}
+                    <span className="tooltiptext">{this.helpText(edgePrompts.citation)}</span>
+                  </Label>
                 </Col>
                 <Col sm={9}>
                   <Input type="text" name="citation"
@@ -1012,7 +1033,11 @@ class EdgeEditor extends UNISYS.Component {
               </FormGroup>
               <FormGroup row hidden={edgePrompts.notes.hidden}>
                 <Col sm={3} style={{hyphens: 'auto'}} className="pr-0">
-                  <Label for="notes" className="tooltipAnchor small text-muted"><i className="fas fa-question-circle"></i>{edgePrompts.notes.label}<span className="tooltiptext">{this.helpText(edgePrompts.notes)}</span></Label>
+                  <Label for="notes" className="tooltipAnchor small text-muted">
+                    <div className="badge">?</div>
+                    {edgePrompts.notes.label}
+                    <span className="tooltiptext">{this.helpText(edgePrompts.notes)}</span>
+                  </Label>
                 </Col>
                 <Col sm={9}>
                   <Input type="textarea" name="notes"
@@ -1026,7 +1051,11 @@ class EdgeEditor extends UNISYS.Component {
               </FormGroup>
               <FormGroup row hidden={edgePrompts.info.hidden}>
                 <Col sm={3} style={{hyphens: 'auto'}} className="pr-0">
-                  <Label for="info" className="tooltipAnchor small text-muted"><i className="fas fa-question-circle"></i>{edgePrompts.info.label}<span className="tooltiptext">{this.helpText(edgePrompts.info)}</span></Label>
+                  <Label for="info" className="tooltipAnchor small text-muted">
+                    <div className="badge">?</div>
+                    {edgePrompts.info.label}
+                    <span className="tooltiptext">{this.helpText(edgePrompts.info)}</span>
+                  </Label>
                 </Col>
                 <Col sm={9}>
                   <Input type="text" name="info"

--- a/build/app/view/netcreate/components/InfoPanel.jsx
+++ b/build/app/view/netcreate/components/InfoPanel.jsx
@@ -155,7 +155,7 @@ class InfoPanel extends UNISYS.Component {
   /*/
   /*/
   render() {
-    let { tabpanelHeight, tableHeight, hideDragger, draggerTop, bIgnoreTableUpdates, filtersSummary} = this.state;
+    let { activeTab, tabpanelHeight, tableHeight, hideDragger, draggerTop, bIgnoreTableUpdates, filtersSummary} = this.state;
     //send flag in with tableheight
     return (
       <div>
@@ -164,7 +164,7 @@ class InfoPanel extends UNISYS.Component {
           <Nav tabs>
             <NavItem>
               <NavLink
-                className={classnames({ active: this.state.activeTab === '1' })}
+                className={classnames({ active: activeTab === '1' })}
                 onClick={() => { this.toggle('1'); this.sendGA('Graph', window.location); } }
               >
                 Graph
@@ -172,7 +172,7 @@ class InfoPanel extends UNISYS.Component {
             </NavItem>
             <NavItem>
               <NavLink
-                className={classnames({ active: this.state.activeTab === '2' })}
+                className={classnames({ active: activeTab === '2' })}
                 onClick={() => { this.toggle('2'); this.sendGA('Filter', window.location); }}
               >
                 Filters
@@ -180,7 +180,7 @@ class InfoPanel extends UNISYS.Component {
             </NavItem>
             <NavItem>
               <NavLink
-                className={classnames({ active: this.state.activeTab === '3' })}
+                className={classnames({ active: activeTab === '3' })}
                 onClick={() => { this.toggle('3'); this.sendGA('Nodes Table', window.location); }}
               >
                 Nodes Table
@@ -188,7 +188,7 @@ class InfoPanel extends UNISYS.Component {
             </NavItem>
             <NavItem>
               <NavLink
-                className={classnames({ active: this.state.activeTab === '4' })}
+                className={classnames({ active: activeTab === '4' })}
                 onClick={() => { this.toggle('4'); this.sendGA('Edges Table', window.location); }}
               >
                 Edges Table
@@ -196,7 +196,7 @@ class InfoPanel extends UNISYS.Component {
             </NavItem>
             <NavItem>
               <NavLink
-                className={classnames({ active: this.state.activeTab === '5' })}
+                className={classnames({ active: activeTab === '5' })}
                 onClick={() => { this.toggle('5'); this.sendGA('Vocabulary', window.location); }}
               >
                 Vocabulary
@@ -204,14 +204,14 @@ class InfoPanel extends UNISYS.Component {
             </NavItem>
             <NavItem>
               <NavLink
-                className={classnames({ active: this.state.activeTab === '6' })}
+                className={classnames({ active: activeTab === '6' })}
                 onClick={() => { this.toggle('6'); this.sendGA('Help', window.location); }}
               >
                 Help
               </NavLink>
             </NavItem>
           </Nav>
-          <TabContent activeTab={this.state.activeTab} style={{height:'100%',overflow: 'hidden', backgroundColor: 'rgba(0,0,0,0.1)'}}>
+          <TabContent activeTab={activeTab} style={{height:'100%',overflow: 'hidden', backgroundColor: 'rgba(0,0,0,0.1)'}}>
             <TabPane tabId="1">
             </TabPane>
             <TabPane tabId="2">
@@ -220,14 +220,14 @@ class InfoPanel extends UNISYS.Component {
             <TabPane tabId="3">
               <Row>
                 <Col sm="12">
-                  <NodeTable tableHeight={tableHeight} bIgnoreTableUpdates={bIgnoreTableUpdates}/>
+                  {activeTab==="3" && <NodeTable tableHeight={tableHeight} bIgnoreTableUpdates={bIgnoreTableUpdates}/> }
                 </Col>
               </Row>
             </TabPane>
             <TabPane tabId="4">
               <Row>
                 <Col sm="12">
-                  <EdgeTable tableHeight={tableHeight} bIgnoreTableUpdates={bIgnoreTableUpdates} />
+                  {activeTab==="4" && <EdgeTable tableHeight={tableHeight} bIgnoreTableUpdates={bIgnoreTableUpdates} /> }
                 </Col>
               </Row>
             </TabPane>

--- a/build/app/view/netcreate/components/MarkdownNote.jsx
+++ b/build/app/view/netcreate/components/MarkdownNote.jsx
@@ -1,0 +1,54 @@
+/*
+    Optimized Markdwon React Component
+
+    This is based on Joshua's implementation of Markdown React in NodeTable and EdgeTable.
+
+    This component wrap the MDReactComponent and only updates when the text changes.
+
+ */
+
+
+import MDReactComponent from 'markdown-react-js';
+const mdplugins = {
+  emoji: require('markdown-it-emoji')
+};
+
+const React = require('react');
+const UNISYS = require('unisys/client');
+
+
+class MarkdownNote extends UNISYS.Component {
+  constructor() {
+    super();
+    this.markdownIterate = this.markdownIterate.bind(this);
+  }
+
+  markdownIterate(Tag, props, children) {
+    if (Tag === 'a') {
+      props.target = '_blank';
+    }
+    return <Tag {...props}>{children}</Tag>;
+  }
+
+  shouldComponentUpdate(np,ns) {
+    let bReturn = true;
+    if (this.text === np.text) bReturn = false;
+    else this.text = np.text;
+    return bReturn;
+  }
+
+  render() {
+    const { text } = this.props;
+    return (
+      <MDReactComponent
+        text={text}
+        onIterate={this.markdownIterate}
+        markdownOptions={{ typographer: true, linkify: true }}
+        plugins={[mdplugins.emoji]}
+      />
+    );
+  }
+
+}
+
+module.exports = MarkdownNote;

--- a/build/app/view/netcreate/components/NetGraph.jsx
+++ b/build/app/view/netcreate/components/NetGraph.jsx
@@ -99,7 +99,10 @@ class NetGraph extends UNISYS.Component {
         <div style={{ height: '100%' }}>
           <div style={{ margin: '10px 0 0 10px' }}>
             <div className="tooltipAnchor">
-                <span style={{ fontSize: '9px' }}><i className="fas fa-question-circle"></i>NETGRAPH for {this.AppState('TEMPLATE').name}</span>
+              <span style={{ fontSize: '9px' }}>
+                <div className="badge">?</div>
+                NETGRAPH for {this.AppState('TEMPLATE').name}
+              </span>
                 <span style={{ fontSize: '12px' }} className="tooltiptext">{this.AppState('TEMPLATE').description}</span>
             </div>
           </div>

--- a/build/app/view/netcreate/components/NodeSelector.jsx
+++ b/build/app/view/netcreate/components/NodeSelector.jsx
@@ -935,8 +935,11 @@ class NodeSelector extends UNISYS.Component {
             <FormText><b>NODE {this.state.formData.id||''}</b></FormText>
             <FormGroup row>
               <Col sm={3} style={{hyphens: 'auto'}} className="pr-0">
-                <Label for="nodeLabel" className="tooltipAnchor small text-muted">
-                <i className="fas fa-question-circle"></i>{nodePrompts.label.label}<span className="tooltiptext">{this.helpText(nodePrompts.label)}</span></Label>
+                  <Label for="nodeLabel" className="tooltipAnchor small text-muted">
+                    <div className="badge">?</div>
+                    {nodePrompts.label.label}
+                    <span className="tooltiptext">{this.helpText(nodePrompts.label)}</span>
+                  </Label>
               </Col>
               <Col sm={9}>
                 <AutoComplete
@@ -958,7 +961,11 @@ class NodeSelector extends UNISYS.Component {
             </div>
             <FormGroup row hidden={nodePrompts.type.hidden}>
               <Col sm={3} style={{hyphens: 'auto'}} className="pr-0">
-                <Label for="type" className="tooltipAnchor small text-muted"><i className="fas fa-question-circle"></i>{nodePrompts.type.label}<span className="tooltiptext">{this.helpText(nodePrompts.type)}</span></Label>
+                  <Label for="type" className="tooltipAnchor small text-muted">
+                    <div className="badge">?</div>
+                    {nodePrompts.type.label}
+                    <span className="tooltiptext">{this.helpText(nodePrompts.type)}</span>
+                  </Label>
               </Col>
               <Col sm={9}>
                 <Input type="select" name="type" id="typeSelect"
@@ -974,7 +981,11 @@ class NodeSelector extends UNISYS.Component {
             </FormGroup>
             <FormGroup row hidden={nodePrompts.notes.hidden}>
               <Col sm={3} style={{hyphens: 'auto'}} className="pr-0">
-                <Label for="notes" className="tooltipAnchor small text-muted"><i className="fas fa-question-circle"></i>{nodePrompts.notes.label}<span className="tooltiptext">{this.helpText(nodePrompts.notes)}</span></Label>
+                  <Label for="notes" className="tooltipAnchor small text-muted">
+                    <div className="badge">?</div>
+                    {nodePrompts.notes.label}
+                    <span className="tooltiptext">{this.helpText(nodePrompts.notes)}</span>
+                  </Label>
               </Col>
               <Col sm={9}>
                 <Input type="textarea" name="note" id="notesText"
@@ -988,7 +999,11 @@ class NodeSelector extends UNISYS.Component {
             </FormGroup>
             <FormGroup row hidden={nodePrompts.info.hidden}>
               <Col sm={3} style={{hyphens: 'auto'}} className="pr-0">
-                <Label for="info" className="tooltipAnchor small text-muted"><i className="fas fa-question-circle"></i>{nodePrompts.info.label}<span className="tooltiptext">{this.helpText(nodePrompts.info)}</span></Label>
+                  <Label for="info" className="tooltipAnchor small text-muted">
+                    <div className="badge">?</div>
+                    {nodePrompts.info.label}
+                    <span className="tooltiptext">{this.helpText(nodePrompts.info)}</span>
+                  </Label>
               </Col>
               <Col sm={9}>
                 <Input type="text" name="info" id="info"

--- a/build/app/view/netcreate/components/SaveEditsDialog.jsx
+++ b/build/app/view/netcreate/components/SaveEditsDialog.jsx
@@ -1,0 +1,111 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  ## OVERVIEW
+
+  The DuplicateNodeDialog is displayed when the user is trying to add a new
+  node that share the same label as an existing node.  It presents the user
+  with two options:
+  * Edit the existing ndoe
+  * Continue adding the new node
+  
+  The dialog is displayed next to the node label so that the user can make
+  a decision.
+  
+  We allow duplicate nodes because there might be places/people with the
+  same name.
+  
+  ## PROPS
+      nodeID
+
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+var DBG = true;
+
+
+/// UNISYS INITIALIZE REQUIRES for REACT ROOT /////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const UNISYS = require('unisys/client');
+var   UDATA  = null;
+
+/// LIBRARIES /////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const React = require('react');
+const ReactStrap = require('reactstrap');
+const { TabContent, TabPane, Nav, NavItem, NavLink, Row, Col, Button } = ReactStrap;
+const classnames = require('classnames');
+
+const Help = require('./Help');
+const NodeTable = require('./NodeTable');
+const EdgeTable = require('./EdgeTable');
+
+
+/// REACT COMPONENT ///////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// export a class object for consumption by brunch/require
+class SaveChangesDialog extends UNISYS.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      nodePrompts: this.AppState('TEMPLATE').nodePrompts,
+    }
+
+    this.handleEdit = this.handleEdit.bind(this);
+    this.handleCancel = this.handleCancel.bind(this);
+
+    /// Initialize UNISYS DATA LINK for REACT
+    UDATA = UNISYS.NewDataLink(this);
+
+  } // constructor
+
+
+
+  /// UI EVENT HANDLERS /////////////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /*/ Select the node for editing
+  /*/
+  handleEdit(event) {
+    event.preventDefault();
+    let nodeID = parseInt(event.target.value);
+    UDATA.LocalCall('SOURCE_SELECT', { nodeIDs: [nodeID] });
+  }
+
+  handleCancel () {
+    event.preventDefault();
+    
+  }
+
+  /// REACT LIFECYCLE METHODS ///////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /*/ This is not yet implemented as of React 16.2.  It's implemented in 16.3.
+      getDerivedStateFromProps (props, state) {
+        console.error('getDerivedStateFromProps!!!');
+      }
+  /*/
+  /*/ This this fires after render().
+  /*/
+  componentDidMount() {
+    let tabpanel = document.getElementById('tabpanel');
+    this.setState({
+      tabpanelTop: tabpanel.offsetTop
+    });
+  }
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /*/
+  /*/
+  render() {
+    let { nodePrompts } = this.state;
+    return (
+      <Modal>
+        <ModalBody>You've made changes to the Node.  Are you sure you want to </ModalBody>
+      </Modal>
+    );
+  }
+
+} // class SaveChangesDialog
+
+
+/// EXPORT REACT COMPONENT ////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+module.exports = SaveChangesDialog;

--- a/build/app/view/netcreate/components/ToolTips.css
+++ b/build/app/view/netcreate/components/ToolTips.css
@@ -105,3 +105,11 @@
   text-decoration: none;
   cursor: pointer;
   }				
+  
+/* (?) Badge overrides bootstrap .badge */
+.tooltipAnchor .badge {
+  color: rgba(256,256,256,0.6);
+  background-color: rgba(108,117,125,0.4); /* bootstrap `text-muted` */
+  vertical-align: text-top;
+  margin-right: 2pt;
+}

--- a/build/app/view/netcreate/nc-logic.js
+++ b/build/app/view/netcreate/nc-logic.js
@@ -173,27 +173,29 @@ MOD.Hook("LOADASSETS", () => {
     }
     // don't use cache, but instead try loading standalone files
     console.warn(PR,"STANDALONE MODE: 'LOADASSETS' is using files (USE_CACHE=false)");
-
     // added by Joshua to check for alternative datasets in the folder
     let urlParams = new URLSearchParams(window.location.search);
     let dataset = urlParams.get('dataset');
     if(dataset == null) dataset = "standalone";
-
-    let p1 = DATASTORE.PromiseJSONFile("data/" + dataset + "-db.json")
-    .then(data => {
-      m_ConvertData(data);
-      m_RecalculateAllEdgeWeights(data);
-      UDATA.SetAppState("D3DATA", data);
-      // Save off local reference because we don't have D3DATA AppStateChange handler
-      D3DATA = data;
+    return new Promise((resolve) => {
+      (async () => {
+        let p1 = await DATASTORE.PromiseJSONFile("data/" + dataset + "-db.json")
+          .then(data => {
+            m_ConvertData(data);
+            m_RecalculateAllEdgeWeights(data);
+            UDATA.SetAppState("D3DATA", data);
+            // Save off local reference because we don't have D3DATA AppStateChange handler
+            D3DATA = data;
+          });
+        // load template
+        let p2 = await DATASTORE.PromiseJSONFile("data/" + dataset + "-template.json")
+          .then(data => {
+            TEMPLATE = data;
+            UDATA.SetAppState("TEMPLATE", TEMPLATE);
+          });
+        resolve();
+      })();
     });
-    // load template
-    let p2 = DATASTORE.PromiseJSONFile("data/" + dataset + "-template.json")
-    .then(data => {
-      TEMPLATE = data;
-      UDATA.SetAppState("TEMPLATE", TEMPLATE);
-    });
-    return Promise.all([p1,p2]);
   }
   // if got this far...
   // NOT STANDALONE MODE so load data into D3DATA
@@ -987,8 +989,10 @@ function m_MarkNodeById(id, color) {
   // this.getDeselectedNodeColor(node,color) are not yet implemented
   // to override the properties
   m_SetMatchingNodesByProp({ id }, marked, normal);
-  // Joshua adding so I can ignore on NodeTable update?
-  D3DATA.bMarkedNode = true;
+
+  // 2020-09-09 Removing this check and relying on other NodeTable optimizations. BL
+  // // Joshua adding so I can ignore on NodeTable update?
+  // D3DATA.bMarkedNode = true;
 
   UDATA.SetAppState("D3DATA", D3DATA); // JD had commented this out because it was triggering a nodetable update that was eating cycles even though nothing had changed
 }

--- a/build/brunch-config.js
+++ b/build/brunch-config.js
@@ -113,8 +113,14 @@ module.exports = {
 /*/ overrides: {
       // env 'classroom' is set by npm start / npm run start
       classroom: {
+        optimize: true,
+        sourceMaps: false,
         plugins: {
-          autoReload: { enabled: false }
+          autoReload: { enabled: false },
+          terser: {
+            ecma: 2016,
+            mangle: false
+          }
         },
         hooks: {
           onCompile() {
@@ -131,7 +137,7 @@ module.exports = {
       // env 'package' is set by npm run package
       package: {
         optimize: false,
-        sourceMaps: true,
+        sourceMaps: false,
         plugins: {
           autoReload: { enabled: false }
         },

--- a/build/brunch-server.js
+++ b/build/brunch-server.js
@@ -7,6 +7,7 @@
 
 /// LIBRARIES /////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const COMPRESS   = require('compression');
 const EXPRESS    = require('express');
 const COOKIEP    = require('cookie-parser');
 const APP        = EXPRESS();
@@ -43,6 +44,8 @@ module.exports = (config, callback) => {
     const PATH_TEMPLATE = PATH.join(__dirname,'/app/assets');
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// compress all responses
+    APP.use(COMPRESS());
 /// configure cookies middleware (appears in req.cookies)
     APP.use(COOKIEP());
 /// configure headers to allow cross-domain requests of media elements

--- a/build/package-lock.json
+++ b/build/package-lock.json
@@ -4507,7 +4507,6 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
       "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
-      "dev": true,
       "requires": {
         "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
@@ -4719,17 +4718,6 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
       "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
       "dev": true
-    },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
-      }
     },
     "ansi-align": {
       "version": "3.0.0",
@@ -5271,12 +5259,6 @@
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.3.tgz",
       "integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA==",
-      "dev": true
-    },
-    "async": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
       "dev": true
     },
     "async-each": {
@@ -7621,12 +7603,6 @@
         "tslib": "^1.10.0"
       }
     },
-    "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "dev": true
-    },
     "camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -7659,16 +7635,6 @@
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.5.tgz",
       "integrity": "sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw==",
       "dev": true
-    },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
-      "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
-      }
     },
     "chalk": {
       "version": "1.1.3",
@@ -8259,25 +8225,6 @@
         "tiny-emitter": "^2.0.0"
       }
     },
-    "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dev": true,
-      "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
-        "wordwrap": "0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true
-        }
-      }
-    },
     "clone-deep": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
@@ -8428,6 +8375,35 @@
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
+    },
+    "compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "requires": {
+        "mime-db": ">= 1.43.0 < 2"
+      }
+    },
+    "compression": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "requires": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+        }
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -9116,7 +9092,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       },
@@ -9124,16 +9099,9 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -13947,12 +13915,6 @@
       "resolved": "https://registry.npmjs.org/lokijs/-/lokijs-1.5.8.tgz",
       "integrity": "sha512-D8E3TBrY35o1ELnonp2MF8b3wKu2tVNl2TqRjvS+95oPMMe7OoIAxNY1qr+5BEZwnWn2V4ErAjVt000DonM+FA=="
     },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
-    },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
@@ -14318,14 +14280,12 @@
     "mime-db": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
-      "dev": true
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
     },
     "mime-types": {
       "version": "2.1.27",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
       "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
-      "dev": true,
       "requires": {
         "mime-db": "1.44.0"
       }
@@ -14598,8 +14558,7 @@
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
-      "dev": true
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "neo-async": {
       "version": "2.6.2",
@@ -15478,6 +15437,11 @@
       "requires": {
         "ee-first": "1.1.1"
       }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "once": {
       "version": "1.4.0",
@@ -18855,15 +18819,6 @@
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.4.tgz",
       "integrity": "sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug=="
     },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "requires": {
-        "align-text": "^0.1.1"
-      }
-    },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -18924,8 +18879,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -20855,6 +20809,34 @@
         }
       }
     },
+    "terser-brunch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/terser-brunch/-/terser-brunch-4.0.0.tgz",
+      "integrity": "sha512-bmT9+/7HHwmgCbfZ0IaX26em9d2SpyoxSiiO+xSHJU4EG0FLsk52M7bRcTF/xMaSPl9LXTVkqjgSEllFmcoUFg==",
+      "dev": true,
+      "requires": {
+        "anymatch": "^3",
+        "terser": "^4.4"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "dev": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
+        }
+      }
+    },
     "terser-webpack-plugin": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-3.1.0.tgz",
@@ -21235,33 +21217,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
-    },
-    "uglify-js": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
-      "integrity": "sha1-ZeovswWck5RpLxX+2HwrNsFrmt8=",
-      "dev": true,
-      "requires": {
-        "async": "~0.2.6",
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
-      }
-    },
-    "uglify-js-brunch": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/uglify-js-brunch/-/uglify-js-brunch-2.10.0.tgz",
-      "integrity": "sha1-YM0PtlKIegLOarzRWI3lXcw0bwU=",
-      "dev": true,
-      "requires": {
-        "uglify-js": "~2.6.1"
-      }
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true
     },
     "ultron": {
       "version": "1.0.2",
@@ -21682,8 +21637,7 @@
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-      "dev": true
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "vfile": {
       "version": "4.2.0",
@@ -22556,12 +22510,6 @@
         }
       }
     },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true
-    },
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -22650,18 +22598,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
       "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
       "dev": true
-    },
-    "yargs": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "dev": true,
-      "requires": {
-        "camelcase": "^1.0.2",
-        "cliui": "^2.1.0",
-        "decamelize": "^1.0.0",
-        "window-size": "0.1.0"
-      }
     },
     "zwitch": {
       "version": "1.0.5",

--- a/build/package.json
+++ b/build/package.json
@@ -43,13 +43,14 @@
     "eslint-plugin-react": "^7.10.0",
     "path": "^0.12.7",
     "react-is": "^16.13.1",
-    "tracer": "^0.9.1",
-    "uglify-js-brunch": "^2.10.0"
+    "terser-brunch": "^4.0.0",
+    "tracer": "^0.9.1"
   },
   "dependencies": {
     "babel-polyfill": "^6.26.0",
     "bootstrap": "^4.3.1",
     "classnames": "^2.2.6",
+    "compression": "^1.7.4",
     "cookie-parser": "^1.4.3",
     "d3": "^4.13.0",
     "fs-extra": "^6.0.1",


### PR DESCRIPTION
Date Released: 9/17/2020

Version 1.3.1 release focuses on performance optimizations, especially around network  #129

#### Network Reliability Reporting
To improve the use of Net.Create on low-quality networks:

* Extend the wait time for heartbeats. Both the server and the client will wait for 10 seconds before declaring a disconnect. Heartbeats should be generated by the server every 5 seconds, so this gives us a large window.

* Show a specific "Client Disconnect" or "Server Disconnect" with a timestamp error for users.

    "Client Disconnected" -- Client did not receive a "ping" heartbeat from the server within the time allowed. Usually this is a result of the client losing the internet connection.

    "Server Disconnected" -- Either the server shut down, or the server did not receive a "pong" response from the client within the time allowed. Usually this is a result of the server initiating the disconnect as it shuts down.

* Log the missing "pong" message to the server logs along with the UADDR so you can identify the machine thats down. e.g.
11:30:39 tacitus SRV-NET - UADDR_02 pong not received before time ran out -- CLIENT CONNECTION DEAD!

* Add GZIP compression for all files. In some cases resulting in an 80% reduction in data that has to be sent over the wires.
This isn't a perfect solution but perhaps it'll give us a little more information about what's going on.

* Bugfix: Wrap standalone calls in a promise to prevent LOADASSETS lifecycle errors.  Addresses #132 and #136.

* Replace font-awesome (?) badge with a css badge.  This reduces load time by about 2 seconds. #136.

* Delay blocking javascript loads so that main app page will load and display. #135, #136.

* Display a "Loading Net.Create..." message so user knows the page is loading.  #135, #136.

* Add minification with `terser`.

#### NodeTable / EdgeTable Improvements

* NodeTable and EdgeTable are now only loaded when their respective tab is visible.  This saves about 2 seconds during page processing time. #136.
* Markdown rendering has been optimized. #139 
* NodeTables and EdgeTables no longer disappear when a node is selected. #137, #138 
* Degrees are now displayed again.  6fc35cc6770eb2ad93235d93a865ff4510608ead
* Properly unmount NodeTable and EdgeTable db864d645515e632a196f07a37750493b5ffd9df

