### PR TITLE
Export

### DIFF
--- a/build/app/view/netcreate/NetCreate.jsx
+++ b/build/app/view/netcreate/NetCreate.jsx
@@ -44,10 +44,13 @@ const PR           = PROMPTS.Pad('ACD');
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const React        = require('react');
 const { Route }    = require('react-router-dom');
+const ReactStrap   = require('reactstrap');
+const { Button } = ReactStrap;
 const NetGraph     = require('./components/NetGraph');
 const Search       = require('./components/Search');
 const NodeSelector = require('./components/NodeSelector');
 const InfoPanel    = require('./components/InfoPanel');
+const FiltersPanel = require('./components/filter/FiltersPanel');
 const NCLOGIC      = require('./nc-logic'); // require to bootstrap data loading
 const FILTERLOGIC  = require('./filter-logic'); // handles filtering functions
 
@@ -62,7 +65,9 @@ const FILTERLOGIC  = require('./filter-logic'); // handles filtering functions
           isConnected: true,
           isLoggedIn: false,
           requireLogin: this.AppState('TEMPLATE').requireLogin,
-          disconnectMsg: ''
+          disconnectMsg: '',
+          layoutNodesOpen: true,
+          layoutFiltersOpen: false
         };
         this.OnDOMReady(()=>{
           if (DBG) console.log(PR,'OnDOMReady');
@@ -85,8 +90,10 @@ const FILTERLOGIC  = require('./filter-logic'); // handles filtering functions
           // so that we can show a message explaining the cause of disconnect.
           // this.setState({ isConnected: false });
         });
+
         this.onStateChange_SESSION = this.onStateChange_SESSION.bind(this);
         this.onDisconnect = this.onDisconnect.bind(this);
+        this.onFilterBtnClick = this.onFilterBtnClick.bind(this);
 
         this.OnAppStateChange('SESSION', this.onStateChange_SESSION);
 
@@ -124,10 +131,18 @@ const FILTERLOGIC  = require('./filter-logic'); // handles filtering functions
         this.AppStateChangeOff('SESSION',this.onStateChange_SESSION);
       }
 
+    /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+      onFilterBtnClick(e) {
+        this.setState(state => {
+          return {layoutFiltersOpen: !state.layoutFiltersOpen}
+        })
+      }
+
+
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /*/ Define the component structure of the web application
   /*/ render() {
-        const { isLoggedIn, disconnectMsg } = this.state;
+        const { isLoggedIn, disconnectMsg, layoutNodesOpen, layoutFiltersOpen } = this.state;
 
         // show or hide graph
         // Use 'visibiliity' css NOT React's 'hidden' so size is properly
@@ -137,7 +152,12 @@ const FILTERLOGIC  = require('./filter-logic'); // handles filtering functions
 
         return (
           <div>
-            <div hidden={this.state.isConnected} style={{ width:'100%',height:'38px',position:'fixed',backgroundColor:'rgba(256,0,0,0.5',display:'flex',flexDirection:'column',justifyContent:'space-evenly',alignItems:'center',zIndex:'3000'}}>
+            <div hidden={this.state.isConnected} style={{
+              width: '100%', height: '38px', position: 'fixed',
+              backgroundColor: 'rgba(256,0,0,0.5',
+              display: 'flex', flexDirection: 'column',
+              justifyContent: 'space-evenly', alignItems: 'center', zIndex: '3000'
+            }}>
               <div style={{color:'#fff',width:'100%',textAlign:'center'}}>
                 <b>{disconnectMsg}!</b> Your changes will not be saved!  Please report "{disconnectMsg}" to your administrator to restart the graph.
               </div>
@@ -165,6 +185,32 @@ const FILTERLOGIC  = require('./filter-logic'); // handles filtering functions
                 request information contained on this website in an accessible
                 format.</div>
               </div>
+              {layoutFiltersOpen
+                // OPEN
+                ? <div id="right" style={{
+                    marginTop: '38px', padding: '0 5px', backgroundColor: '#5c656d',
+                    borderTopLeftRadius: '10px', width: 'auto'
+                  }}>
+                    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'end' }}>
+                      <Button onClick={this.onFilterBtnClick}
+                        style={{ width: '100px' }}
+                      >
+                        FILTER &gt;
+                      </Button>
+                      <FiltersPanel />
+                    </div>
+                  </div>
+                // CLOSED
+                : <div id="right" style={{
+                  marginTop: '38px', paddingTop: '0px', backgroundColor: '#5c656d',
+                  width: '10px', height: '100%'
+                }}>
+                  <Button
+                    onClick={this.onFilterBtnClick}
+                    style={{ width: '90px', height: '51px', float: 'right' }}
+                  >&lt; FILTER</Button>
+                  </div>
+              }
             </div>
           </div>
         ); // end return

--- a/build/app/view/netcreate/NetCreate.jsx
+++ b/build/app/view/netcreate/NetCreate.jsx
@@ -188,7 +188,7 @@ const FILTERLOGIC  = require('./filter-logic'); // handles filtering functions
               {layoutFiltersOpen
                 // OPEN
                 ? <div id="right" style={{
-                    marginTop: '38px', padding: '0 5px', backgroundColor: '#5c656d',
+                    marginTop: '38px', padding: '0 5px', backgroundColor: '#6c757d',
                     borderTopLeftRadius: '10px', width: 'auto'
                   }}>
                     <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'end' }}>
@@ -202,13 +202,13 @@ const FILTERLOGIC  = require('./filter-logic'); // handles filtering functions
                   </div>
                 // CLOSED
                 : <div id="right" style={{
-                  marginTop: '38px', paddingTop: '0px', backgroundColor: '#5c656d',
-                  width: '10px', height: '100%'
-                }}>
-                  <Button
-                    onClick={this.onFilterBtnClick}
-                    style={{ width: '90px', float: 'right' }}
-                  >&lt; FILTER</Button>
+                    marginTop: '38px', paddingTop: '0px', backgroundColor: '#6c757d',
+                    width: '10px', height: '100%'
+                  }}>
+                    <Button
+                      onClick={this.onFilterBtnClick}
+                      style={{ width: '90px', float: 'right' }}
+                    >&lt; FILTER</Button>
                   </div>
               }
             </div>

--- a/build/app/view/netcreate/NetCreate.jsx
+++ b/build/app/view/netcreate/NetCreate.jsx
@@ -127,7 +127,7 @@ const FILTERLOGIC  = require('./filter-logic'); // handles filtering functions
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /*/ Define the component structure of the web application
   /*/ render() {
-    const { isLoggedIn, disconnectMsg } = this.state;
+        const { isLoggedIn, disconnectMsg } = this.state;
 
         // show or hide graph
         // Use 'visibiliity' css NOT React's 'hidden' so size is properly

--- a/build/app/view/netcreate/NetCreate.jsx
+++ b/build/app/view/netcreate/NetCreate.jsx
@@ -128,8 +128,13 @@ const FILTERLOGIC  = require('./filter-logic'); // handles filtering functions
   /*/ Define the component structure of the web application
   /*/ render() {
     const { isLoggedIn, disconnectMsg } = this.state;
-        let hideGraph = false;
-        if (this.state.requireLogin && !isLoggedIn) hideGraph = true;
+
+        // show or hide graph
+        // Use 'visibiliity' css NOT React's 'hidden' so size is properly
+        // calculated on init
+        let hideGraph = 'visible';
+        if (this.state.requireLogin && !isLoggedIn) hideGraph = 'hidden';
+
         return (
           <div>
             <div hidden={this.state.isConnected} style={{ width:'100%',height:'38px',position:'fixed',backgroundColor:'rgba(256,0,0,0.5',display:'flex',flexDirection:'column',justifyContent:'space-evenly',alignItems:'center',zIndex:'3000'}}>
@@ -140,8 +145,10 @@ const FILTERLOGIC  = require('./filter-logic'); // handles filtering functions
             <Route path='/edit/:token' exact={true} component={SessionShell}/>
             <Route path='/edit' exact={true} component={SessionShell}/>
             <Route path='/' exact={true} component={SessionShell}/>
-            <div hidden={hideGraph} style={{display:'flex', flexFlow:'row nowrap',
-                width:'100%', height:'100vh',overflow:'hidden'}}>
+            <div style={{display:'flex', flexFlow:'row nowrap',
+              width: '100%', height: '100vh', overflow: 'hidden',
+              visibility: hideGraph
+            }}>
               <div id="left" style={{backgroundColor:'#EEE',flex:'1 1 25%',maxWidth:'400px',padding:'10px',overflow:'scroll',marginTop:'38px'}}>
                 <div style={{display:'flex',flexFlow:'column nowrap'}}>
                   <Search/>

--- a/build/app/view/netcreate/NetCreate.jsx
+++ b/build/app/view/netcreate/NetCreate.jsx
@@ -193,7 +193,7 @@ const FILTERLOGIC  = require('./filter-logic'); // handles filtering functions
                   }}>
                     <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'end' }}>
                       <Button onClick={this.onFilterBtnClick}
-                        style={{ width: '100px' }}
+                        style={{ width: '90px' }}
                       >
                         FILTER &gt;
                       </Button>
@@ -207,7 +207,7 @@ const FILTERLOGIC  = require('./filter-logic'); // handles filtering functions
                 }}>
                   <Button
                     onClick={this.onFilterBtnClick}
-                    style={{ width: '90px', height: '51px', float: 'right' }}
+                    style={{ width: '90px', float: 'right' }}
                   >&lt; FILTER</Button>
                   </div>
               }

--- a/build/app/view/netcreate/components/EdgeTable.jsx
+++ b/build/app/view/netcreate/components/EdgeTable.jsx
@@ -397,9 +397,8 @@ class EdgeTable extends UNISYS.Component {
         edgePrompts.category.hidden = true;
       }
 
-
-      let { tableHeight } = this.props;
-      let styles = `thead, tbody { font-size: 0.8em }
+      const { tableHeight } = this.props;
+      const styles = `thead, tbody { font-size: 0.8em }
                     thead { position: relative; }
                     tbody { overflow: auto; }
                     .btn-sm { font-size: 0.6rem; padding: 0.1rem 0.2rem }

--- a/build/app/view/netcreate/components/EdgeTable.jsx
+++ b/build/app/view/netcreate/components/EdgeTable.jsx
@@ -4,6 +4,9 @@
 
     EdgeTable is used to to display a table of edges for review.
 
+    It displays D3DATA.
+    But also read FILTEREDD3DATA to show highlight/filtered state
+
 
   ## TO USE
 
@@ -78,6 +81,42 @@ class EdgeTable extends UNISYS.Component {
       // Handle Template updates
       this.OnAppStateChange('TEMPLATE', this.OnTemplateUpdate);
     } // constructor
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/
+/*/ componentDidMount () {
+      if (DBG) console.log('EdgeTable.componentDidMount!');
+      // Explicitly retrieve data because we may not have gotten a D3DATA
+      // update while we were hidden.
+      // filtered data needs to be set before D3Data
+      const FILTEREDD3DATA = UDATA.AppState('FILTEREDD3DATA');
+      this.setState({ filteredEdges: FILTEREDD3DATA.edges },
+        () => {
+          let D3DATA = this.AppState('D3DATA');
+          this.handleDataUpdate(D3DATA);
+        }
+      )
+}
+
+    componentWillUnmount() {
+      this.AppStateChangeOff('D3DATA', this.handleDataUpdate);
+      this.AppStateChangeOff('FILTEREDD3DATA', this.handleFilterDataUpdate);
+      this.AppStateChangeOff('TEMPLATE', this.OnTemplateUpdate);
+    }
+
+  displayUpdated(nodeEdge) {
+      var d = new Date(nodeEdge.meta.revision > 0 ? nodeEdge.meta.updated : nodeEdge.meta.created);
+
+      var year = "" + d.getFullYear();
+      var date = (d.getMonth()+1)+"/"+d.getDate()+"/"+ year.substr(2,4);
+      var time = d.toTimeString().substr(0,5);
+      var dateTime = date+' at '+time;
+      var titleString = "v" + nodeEdge.meta.revision;
+      if(nodeEdge._nlog)
+        titleString += " by " + nodeEdge._nlog[nodeEdge._nlog.length-1];
+      var tag = <span title={titleString}> {dateTime} </span>;
+
+      return tag;
+  }
 
 
 
@@ -419,36 +458,6 @@ class EdgeTable extends UNISYS.Component {
         </div>
       );
     }
-/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/*/
-/*/ componentDidMount () {
-      if (DBG) console.log('EdgeTable.componentDidMount!');
-      // Explicitly retrieve data because we may not have gotten a D3DATA
-      // update while we were hidden.
-      let D3DATA = this.AppState('D3DATA');
-      this.handleDataUpdate(D3DATA);
-    }
-
-    componentWillUnmount() {
-      this.AppStateChangeOff('D3DATA', this.handleDataUpdate);
-      this.AppStateChangeOff('TEMPLATE', this.OnTemplateUpdate);
-    }
-
-  displayUpdated(nodeEdge)
-  {
-      var d = new Date(nodeEdge.meta.revision > 0 ? nodeEdge.meta.updated : nodeEdge.meta.created);
-
-      var year = "" + d.getFullYear();
-      var date = (d.getMonth()+1)+"/"+d.getDate()+"/"+ year.substr(2,4);
-      var time = d.toTimeString().substr(0,5);
-      var dateTime = date+' at '+time;
-      var titleString = "v" + nodeEdge.meta.revision;
-      if(nodeEdge._nlog)
-        titleString += " by " + nodeEdge._nlog[nodeEdge._nlog.length-1];
-      var tag = <span title={titleString}> {dateTime} </span>;
-
-      return tag;
-  }
 } // class EdgeTable
 
 

--- a/build/app/view/netcreate/components/EdgeTable.jsx
+++ b/build/app/view/netcreate/components/EdgeTable.jsx
@@ -71,7 +71,7 @@ class EdgeTable extends UNISYS.Component {
       this.setSortKey               = this.setSortKey.bind(this);
       this.sortSymbol               = this.sortSymbol.bind(this);
 
-      this.sortDirection = -1;
+      this.sortDirection = 1;
 
 
       /// Initialize UNISYS DATA LINK for REACT
@@ -290,7 +290,7 @@ class EdgeTable extends UNISYS.Component {
       if(key != this.state.sortkey) // this is not the current sort, so don't show anything
         return "";
       else
-        return this.sortDirection==-1?"▼":"▲"; // default to "decreasing" and flip if clicked again
+        return this.sortDirection==1?"▼":"▲"; // default to "decreasing" and flip if clicked again
     }
 
 /// UI EVENT HANDLERS /////////////////////////////////////////////////////////

--- a/build/app/view/netcreate/components/EdgeTable.jsx
+++ b/build/app/view/netcreate/components/EdgeTable.jsx
@@ -114,13 +114,12 @@ class EdgeTable extends UNISYS.Component {
   displayUpdated(nodeEdge) {
       var d = new Date(nodeEdge.meta.revision > 0 ? nodeEdge.meta.updated : nodeEdge.meta.created);
 
-      var year = "" + d.getFullYear();
+      var year = String(d.getFullYear());
       var date = (d.getMonth()+1)+"/"+d.getDate()+"/"+ year.substr(2,4);
       var time = d.toTimeString().substr(0,5);
       var dateTime = date+' at '+time;
       var titleString = "v" + nodeEdge.meta.revision;
-      if(nodeEdge._nlog)
-        titleString += " by " + nodeEdge._nlog[nodeEdge._nlog.length-1];
+      if (nodeEdge._nlog) titleString += " by " + nodeEdge._nlog[nodeEdge._nlog.length-1];
       var tag = <span title={titleString}> {dateTime} </span>;
 
       return tag;
@@ -177,8 +176,8 @@ class EdgeTable extends UNISYS.Component {
         return edges.sort( (a,b) => {
           let akey = a.id,
               bkey = b.id;
-          if (akey<bkey) return -1*this.sortDirection;
-          if (akey>bkey) return 1*this.sortDirection;
+          if (akey<bkey) return -1*Number(this.sortDirection);
+          if (akey>bkey) return 1*Number(this.sortDirection);
           return 0;
         });
       }
@@ -217,14 +216,14 @@ class EdgeTable extends UNISYS.Component {
         return edges.sort( (a,b) => {
           let akey = a.attributes[key],
               bkey = b.attributes[key];
-          if (akey<bkey) return -1*this.sortDirection;
-          if (akey>bkey) return 1*this.sortDirection;
+          if (akey<bkey) return -1*Number(this.sortDirection);
+          if (akey>bkey) return 1*Number(this.sortDirection);
           if (akey===bkey) {
             // Secondary sort on Source label
             let source_a = a.source.label;
             let source_b = b.source.label;
-            if (source_a<source_b) return -1*this.sortDirection;
-            if (source_a>source_b) return 1*this.sortDirection;
+            if (source_a<source_b) return -1*Number(this.sortDirection);
+            if (source_a>source_b) return 1*Number(this.sortDirection);
           }
           return 0;
         });
@@ -233,19 +232,17 @@ class EdgeTable extends UNISYS.Component {
     }
 
     /// ---
-    sortByUpdated(edges)
-    {
+    sortByUpdated(edges) {
       if (edges) {
         return edges.sort( (a,b) => {
           let akey = (a.meta.revision > 0 ? a.meta.updated : a.meta.created),
               bkey = (b.meta.revision > 0 ? b.meta.updated : b.meta.created);
-          if (akey<bkey) return -1*this.sortDirection;
-          if (akey>bkey) return 1*this.sortDirection;
+          if (akey<bkey) return -1*Number(this.sortDirection);
+          if (akey>bkey) return 1*Number(this.sortDirection);
           return 0;
         });
       }
       return undefined;
-
     }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/ If no `sortkey` is passed, the sort will use the existing state.sortkey
@@ -259,9 +256,6 @@ class EdgeTable extends UNISYS.Component {
           break;
         case 'target':
           return this.sortByTargetLabel(edges);
-          break;
-        case 'Relationship':
-          return this.sortByAttribute(edges, 'Relationship');
           break;
         case 'Info':
           return this.sortByAttribute(edges, 'Info');
@@ -285,12 +279,9 @@ class EdgeTable extends UNISYS.Component {
       }
     }
 
-    sortSymbol(key)
-    {
-      if(key != this.state.sortkey) // this is not the current sort, so don't show anything
-        return "";
-      else
-        return this.sortDirection==1?"▼":"▲"; // default to "decreasing" and flip if clicked again
+    sortSymbol(key) {
+      if (key !== this.state.sortkey) return ""; // this is not the current sort, so don't show anything
+      else return this.sortDirection===1?"▼":"▲"; // default to "decreasing" and flip if clicked again
     }
 
 /// UI EVENT HANDLERS /////////////////////////////////////////////////////////
@@ -321,11 +312,8 @@ class EdgeTable extends UNISYS.Component {
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/
 /*/ setSortKey (key) {
-
-      if(key == this.state.sortkey)
-        this.sortDirection = (-1 * this.sortDirection);// if this was already the key, flip the direction
-      else
-          this.sortDirection = 1;
+      if (key === this.state.sortkey) this.sortDirection = (-1 * this.sortDirection);// if this was already the key, flip the direction
+      else this.sortDirection = 1;
 
       const edges = this.sortTable(key, this.state.edges);
       this.setState({
@@ -390,8 +378,7 @@ class EdgeTable extends UNISYS.Component {
 /*/ render () {
       let { edgePrompts } = this.state;
 
-      if(edgePrompts.category == undefined) // for backwards compatability
-      {
+      if (edgePrompts.category === undefined) { // for backwards compatability
         edgePrompts.category = {};
         edgePrompts.category.label = "";
         edgePrompts.category.hidden = true;

--- a/build/app/view/netcreate/components/EdgeTable.jsx
+++ b/build/app/view/netcreate/components/EdgeTable.jsx
@@ -37,7 +37,7 @@ const isLocalHost  = (SETTINGS.EJSProp('client').ip === '127.0.0.1') || (locatio
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const React        = require('react');
 const ReactStrap   = require('reactstrap');
-const { Button, Table }    = ReactStrap;
+const { Button }    = ReactStrap;
 const MarkdownNote = require('./MarkdownNote');
 
 const UNISYS   = require('unisys/client');
@@ -386,22 +386,39 @@ class EdgeTable extends UNISYS.Component {
 
       const { tableHeight } = this.props;
       const styles = `thead, tbody { font-size: 0.8em }
-                    thead { position: relative; }
-                    tbody { overflow: auto; }
-                    .btn-sm { font-size: 0.6rem; padding: 0.1rem 0.2rem }
-                    `
+                      .table {
+                        display: table; /* override bootstrap for fixed header */
+                        border-spacing: 0;
+                      }
+                      .table th {
+                        position: -webkit-sticky;
+                        position: sticky;
+                        top: 0;
+                        background-color: #eafcff;
+                        border-top: none;
+                      }
+                      xtbody { overflow: auto; }
+                      .btn-sm { font-size: 0.6rem; padding: 0.1rem 0.2rem }
+                      `
       return (
-           <div style={{overflow:'auto',
-                     position:'relative',display: 'block',  left: '1px', right:'10px',maxHeight: tableHeight, backgroundColor:'#f3f3ff'
-             }}>
+        <div style={{
+          overflow: 'auto',
+          position: 'relative',
+          display: 'block',
+          left: '1px', right: '10px',
+          height: tableHeight,
+          backgroundColor: '#eafcff'
+        }}>
           <style>{styles}</style>
           <Button size="sm" outline hidden
             onClick={this.onToggleExpanded}
           >{this.state.isExpanded ? "Hide Edge Table" : "Show Edge Table"}</Button>
-          <Table hidden={!this.state.isExpanded} hover size="sm"
-                 responsive striped
-                 className="edgetable w-auto"
-          >
+      <table hidden={!this.state.isExpanded}
+        // size="sm" hover responsive striped // ReactStrap properties
+        // Need to use a standard 'table' not ReactStrap so that we can set
+        // the container div height and support non-scrolling headers
+        className="table table-striped table-responsive table-hover table-sm edgetable w-auto"
+      >
             <thead>
               <tr>
                 <th width="4%" hidden={!DBG}><Button size="sm"
@@ -469,7 +486,7 @@ class EdgeTable extends UNISYS.Component {
               </tr>
             ))}
             </tbody>
-          </Table>
+          </table>
         </div>
       );
     }

--- a/build/app/view/netcreate/components/EdgeTable.jsx
+++ b/build/app/view/netcreate/components/EdgeTable.jsx
@@ -335,11 +335,11 @@ class EdgeTable extends UNISYS.Component {
 
 
       let { tableHeight } = this.props;
-      let styles = `
-                    thead, tbody { }
+      let styles = `thead, tbody { font-size: 0.8em }
                     thead { position: relative; }
                     tbody { overflow: auto; }
-`
+                    .btn-sm { font-size: 0.6rem; padding: 0.1rem 0.2rem }
+                    `
       return (
            <div style={{overflow:'auto',
                      position:'relative',display: 'block',  left: '1px', right:'10px',maxHeight: tableHeight, backgroundColor:'#f3f3ff'
@@ -354,11 +354,11 @@ class EdgeTable extends UNISYS.Component {
           >
             <thead>
               <tr>
-                <th width="5%" hidden={!DBG}><Button size="sm"
+                <th width="4%" hidden={!DBG}><Button size="sm"
                       onClick={()=>this.setSortKey("id")}
                     >ID {this.sortSymbol("id")}</Button></th>
                 <th hidden={!DBG}>Size</th>
-                <th width="5%"><div style={{color: '#f3f3ff'}}>_Edit_</div></th>
+                <th width="4%"><div style={{color: '#f3f3ff'}}>_Edit_</div></th>
                 <th hidden={!DBG}>Src ID</th>
                 <th  width="10%"><Button size="sm"
                       onClick={()=>this.setSortKey("source")}
@@ -376,13 +376,13 @@ class EdgeTable extends UNISYS.Component {
                 <th width="10%" hidden={edgePrompts.citation.hidden}><Button size="sm"
                       onClick={()=>this.setSortKey("Citations")}
                     >{edgePrompts.citation.label} {this.sortSymbol("Citations")}</Button></th>
-                <th width="16%" hidden={edgePrompts.notes.hidden}><Button size="sm"
+                <th width="20%" hidden={edgePrompts.notes.hidden}><Button size="sm"
                       onClick={()=>this.setSortKey("Notes")}
                     >{edgePrompts.notes.label} {this.sortSymbol("Notes")}</Button></th>
-                <th  width="16%"hidden={edgePrompts.info.hidden}><Button size="sm"
+                <th  width="10%"hidden={edgePrompts.info.hidden}><Button size="sm"
                       onClick={()=>this.setSortKey("Info")}
                     >{edgePrompts.info.label} {this.sortSymbol("Info")}</Button></th>
-                <th  width="16%"hidden={!isLocalHost}><Button size="sm"
+                <th  width="10%"hidden={!isLocalHost}><Button size="sm"
                       onClick={()=>this.setSortKey("Updated")}
                     >Updated {this.sortSymbol("Updated")}</Button></th>
 

--- a/build/app/view/netcreate/components/EdgeTable.jsx
+++ b/build/app/view/netcreate/components/EdgeTable.jsx
@@ -59,6 +59,7 @@ class EdgeTable extends UNISYS.Component {
         sortkey:      'Relationship'
       };
 
+      this.updateEdgeFilterState = this.updateEdgeFilterState.bind(this);
       this.handleDataUpdate = this.handleDataUpdate.bind(this);
       this.handleFilterDataUpdate = this.handleFilterDataUpdate.bind(this);
       this.OnTemplateUpdate = this.OnTemplateUpdate.bind(this);
@@ -126,37 +127,40 @@ class EdgeTable extends UNISYS.Component {
   }
 
 
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// Set edge filtered status based on current filteredNodes
+  updateEdgeFilterState(edges, filteredEdges) {
+    // add highlight/filter status
+    if (filteredEdges.length > 0) {
+      edges = edges.map(edge => {
+        const filteredEdge = filteredEdges.find(n => n.id === edge.id);
+        edge.isFiltered = !filteredEdge;
+        return edge;
+      });
+    }
+    this.setState({edges});
+  }
 
-/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/*/ Handle updated SELECTION
-/*/
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /*/ Handle updated SELECTION
+  /*/
   handleDataUpdate(data) {
-    // 2020-09-09 Removing this check and relying on other NodeTable optimizations. BL
-    // if(data.bMarkedNode)
-    // {
-    //     data.bMarkedNode = false;
-    // }
-    // else
-    // {
-
     if (data && data.edges) {
-      let edges = this.sortTable(this.state.sortkey, data.edges);
+      const edges = this.sortTable(this.state.sortkey, data.edges);
       const { filteredEdges } = this.state;
-      // add highlight/filter status
-      if (filteredEdges.length > 0) {
-        edges = edges.map(edge => {
-          const filteredEdge = filteredEdges.find(n => n.id === edge.id);
-          if (!filteredEdge) edge.isFiltered = true;
-          return edge;
-        });
-      }
-      this.setState({edges});
+      this.updateEdgeFilterState(edges, filteredEdges);
     }
   }
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   handleFilterDataUpdate(data) {
-    if (data.edges) this.setState( { filteredEdges: data.edges } );
+    if (data.edges) {
+      const filteredEdges = data.edges;
+      this.setState({ filteredEdges }, () => {
+        const edges = this.sortTable(this.state.sortkey, this.state.edges);
+        this.updateEdgeFilterState(edges, filteredEdges);
+      });
+    }
   }
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/build/app/view/netcreate/components/Help.jsx
+++ b/build/app/view/netcreate/components/Help.jsx
@@ -24,83 +24,47 @@ const UNISYS   = require('unisys/client');
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// export a class object for consumption by brunch/require
 class Help extends UNISYS.Component {
-    constructor (props) {
-      super(props);
-      this.state = {isExpanded: true};
-      this.onToggleExpanded = this.onToggleExpanded.bind(this);
-
-      UDATA = UNISYS.NewDataLink(this);
-    } // constructor
-
-/// UI EVENT HANDLERS /////////////////////////////////////////////////////////
-/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/*/
-/*/ onToggleExpanded (event) {
-      this.setState({
-        isExpanded: !this.state.isExpanded
-      })
-    }
-
-/// REACT LIFECYCLE METHODS ///////////////////////////////////////////////////
-/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/*/ This is not yet implemented as of React 16.2.  It's implemented in 16.3.
-    getDerivedStateFromProps (props, state) {
-      console.error('getDerivedStateFromProps!!!');
-    }
-/*/
-/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/*/
-/*/ render () {
-      return (
-        <div className="help"
-             style={{maxWidth:'50%',overflow:'scroll',
-                     position:'fixed',right:'10px',zIndex:'3000'
-             }}>
-          <Button size="sm" outline hidden
-            style={{float:'right'}}
-            onClick={this.onToggleExpanded}
-          >{this.state.isExpanded ? "Hide Help" : "Help"}</Button>
-          <div hidden={!this.state.isExpanded}
-            style={{backgroundColor:'rgba(240,240,240,0.95)',padding:'10px 20px'}}>
-            <h1>Why Net.Create</h1>
-            <p>In Net.Create, users can simultaneously do data entry on nodes and the edges between them.</p>
-            <h1>Navigation</h1>
+  render () {
+    return (
+      <div
+        style={{backgroundColor:'rgba(240,240,240,0.95)',padding:'10px 20px'}}>
+        <h1>Why Net.Create</h1>
+        <p>In Net.Create, users can simultaneously do data entry on nodes and the edges between them.</p>
+        <h1>Navigation</h1>
+        <ul>
+          <li>Recenter the graph -- press the * button</li>
+          <li>Zoom --
             <ul>
-              <li>Recenter the graph -- press the * button</li>
-              <li>Zoom --
-                <ul>
-                  <li>on screen -- use the +/- buttons</li>
-                  <li>mouse -- use mousewheel</li>
-                  <li>trackpad -- two fingers up/down</li>
-                  <li>tablet -- two fingers pinch</li>
-                </ul>
-              </li>
-              <li>Pan -- drag empty space</li>
+              <li>on screen -- use the +/- buttons</li>
+              <li>mouse -- use mousewheel</li>
+              <li>trackpad -- two fingers up/down</li>
+              <li>tablet -- two fingers pinch</li>
             </ul>
-            <h1>Nodes</h1>
-            <ul>
-              <li>Select -- Click on a node, or start typing the node label in
-              the Label field and select a node from the suggestions.</li>
-            </ul>
-            <h1>Edges</h1>
-            <ul>
-              <li>Create -- To create an edge, first select the source node, then
-              click "Add New Edge".</li>
-              <li>Select -- To select an edge, select either of the nodes it is attached to.</li>
-              <li>Editing -- To change the source or target of an existing edge,
-              delete it and create a new one.</li>
-              <li>View Full List -- Click on "Show Edge Table" to view a table
-              of all the edges.  Click on a column header to sort the table by
-              that parameter.</li>
-            </ul>
-            <h1>About Net.Create</h1>
-            <p>Net.Create is funded through the <a href="https://www.nsf.gov/pubs/policydocs/pappguide/nsf09_1/gpg_2.jsp#IID2" target="NSF">EAGER program</a> at <a href="https://www.nsf.gov/" target="NSF">NSF</a> under award #<a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1848655" target="NSF">1848655</a>. <a href="http://www.kalanicraig.com" target="Craig">Kalani Craig</a> is the PI, with Co-PIs <a href="http://www.joshuadanish.com" target="Danish">Joshua Danish</a> and <a href="https://education.indiana.edu/about/directory/profiles/hmelo-silver-cindy.html" target="Hmelo-Silver">Cindy Hmelo-Silver</a>. Software development provided by <a href="http://inquirium.net" target="Inquirium">Inquirium</a>. For more information, see <a href="http://netcreate.org" target="NetCreateOrg">Net.Create.org</a></p>
+          </li>
+          <li>Pan -- drag empty space</li>
+        </ul>
+        <h1>Nodes</h1>
+        <ul>
+          <li>Select -- Click on a node, or start typing the node label in
+          the Label field and select a node from the suggestions.</li>
+        </ul>
+        <h1>Edges</h1>
+        <ul>
+          <li>Create -- To create an edge, first select the source node, then
+          click "Add New Edge".</li>
+          <li>Select -- To select an edge, select either of the nodes it is attached to.</li>
+          <li>Editing -- To change the source or target of an existing edge,
+          delete it and create a new one.</li>
+          <li>View Full List -- Click on "Show Edge Table" to view a table
+          of all the edges.  Click on a column header to sort the table by
+          that parameter.</li>
+        </ul>
+        <h1>About Net.Create</h1>
+        <p>Net.Create is funded through the <a href="https://www.nsf.gov/pubs/policydocs/pappguide/nsf09_1/gpg_2.jsp#IID2" target="NSF">EAGER program</a> at <a href="https://www.nsf.gov/" target="NSF">NSF</a> under award #<a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1848655" target="NSF">1848655</a>. <a href="http://www.kalanicraig.com" target="Craig">Kalani Craig</a> is the PI, with Co-PIs <a href="http://www.joshuadanish.com" target="Danish">Joshua Danish</a> and <a href="https://education.indiana.edu/about/directory/profiles/hmelo-silver-cindy.html" target="Hmelo-Silver">Cindy Hmelo-Silver</a>. Software development provided by <a href="http://inquirium.net" target="Inquirium">Inquirium</a>. For more information, see <a href="http://netcreate.org" target="NetCreateOrg">Net.Create.org</a></p>
 
-          </div>
-        </div>
-      );
-    }
-
+      </div>
+    );
+  }
 } // class Help
 
 

--- a/build/app/view/netcreate/components/Help.jsx
+++ b/build/app/view/netcreate/components/Help.jsx
@@ -9,6 +9,7 @@
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
 
 var DBG = false;
+var UDATA = null;
 
 /// LIBRARIES /////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -27,6 +28,9 @@ class Help extends UNISYS.Component {
       super(props);
       this.state = {isExpanded: true};
       this.onToggleExpanded = this.onToggleExpanded.bind(this);
+      this.onSelectExport = this.onSelectExport.bind(this);
+
+      UDATA = UNISYS.NewDataLink(this);
     } // constructor
 
 
@@ -38,7 +42,11 @@ class Help extends UNISYS.Component {
       this.setState({
         isExpanded: !this.state.isExpanded
       })
-    }
+}
+
+  onSelectExport() {
+    UDATA.LocalCall('EXPORT');
+  }
 
 
 
@@ -63,6 +71,10 @@ class Help extends UNISYS.Component {
           >{this.state.isExpanded ? "Hide Help" : "Help"}</Button>
           <div hidden={!this.state.isExpanded}
             style={{backgroundColor:'rgba(240,240,240,0.95)',padding:'10px'}}>
+            <Button size="sm" outline onClick={this.onSelectExport}>
+              Export Data
+            </Button>
+            <hr />
             <h1>Why Net.Create</h1>
             <p>In Net.Create, users can simultaneously do data entry on nodes and the edges between them.</p>
             <h1>Navigation</h1>

--- a/build/app/view/netcreate/components/Help.jsx
+++ b/build/app/view/netcreate/components/Help.jsx
@@ -63,7 +63,7 @@ class Help extends UNISYS.Component {
       return (
         <div className="help"
              style={{maxWidth:'50%',overflow:'scroll',
-                     position:'fixed',right:'10px',zIndex:2000
+                     position:'fixed',right:'10px',zIndex:'3000'
              }}>
           <Button size="sm" outline hidden
             style={{float:'right'}}

--- a/build/app/view/netcreate/components/Help.jsx
+++ b/build/app/view/netcreate/components/Help.jsx
@@ -28,12 +28,9 @@ class Help extends UNISYS.Component {
       super(props);
       this.state = {isExpanded: true};
       this.onToggleExpanded = this.onToggleExpanded.bind(this);
-      this.onSelectExport = this.onSelectExport.bind(this);
 
       UDATA = UNISYS.NewDataLink(this);
     } // constructor
-
-
 
 /// UI EVENT HANDLERS /////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -42,13 +39,7 @@ class Help extends UNISYS.Component {
       this.setState({
         isExpanded: !this.state.isExpanded
       })
-}
-
-  onSelectExport() {
-    UDATA.LocalCall('EXPORT');
-  }
-
-
+    }
 
 /// REACT LIFECYCLE METHODS ///////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -70,11 +61,7 @@ class Help extends UNISYS.Component {
             onClick={this.onToggleExpanded}
           >{this.state.isExpanded ? "Hide Help" : "Help"}</Button>
           <div hidden={!this.state.isExpanded}
-            style={{backgroundColor:'rgba(240,240,240,0.95)',padding:'10px'}}>
-            <Button size="sm" outline onClick={this.onSelectExport}>
-              Export Data
-            </Button>
-            <hr />
+            style={{backgroundColor:'rgba(240,240,240,0.95)',padding:'10px 20px'}}>
             <h1>Why Net.Create</h1>
             <p>In Net.Create, users can simultaneously do data entry on nodes and the edges between them.</p>
             <h1>Navigation</h1>

--- a/build/app/view/netcreate/components/ImportExport.jsx
+++ b/build/app/view/netcreate/components/ImportExport.jsx
@@ -1,0 +1,101 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  ## OVERVIEW
+
+    Help displays a hideable generic help screen.
+
+
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+var DBG = false;
+var UDATA = null;
+
+/// LIBRARIES /////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const React        = require('react');
+const ReactStrap   = require('reactstrap');
+const { Button, Table }    = ReactStrap;
+
+const UNISYS   = require('unisys/client');
+
+
+/// REACT COMPONENT ///////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// export a class object for consumption by brunch/require
+class ImportExport extends UNISYS.Component {
+  constructor (props) {
+    super(props);
+    this.state = {isExpanded: true};
+    this.onSelectExportNodes = this.onSelectExportNodes.bind(this);
+    this.onSelectExportEdges = this.onSelectExportEdges.bind(this);
+    this.onSelectImportNodes = this.onSelectImportNodes.bind(this);
+    this.onSelectImportEdges = this.onSelectImportEdges.bind(this);
+
+    UDATA = UNISYS.NewDataLink(this);
+  } // constructor
+
+  /// UI EVENT HANDLERS /////////////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  onSelectExportNodes() { UDATA.LocalCall('EXPORT_NODES'); }
+  onSelectExportEdges() { UDATA.LocalCall('EXPORT_EDGES'); }
+
+  onSelectImportNodes() { }
+
+  onSelectImportEdges() { }
+
+/// REACT LIFECYCLE METHODS ///////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  render() {
+    return (
+      <div
+        className="help"
+        style={{
+          width: '50%',
+          maxWidth: '50%',
+          overflow: 'scroll',
+          position: 'fixed',
+          right: '10px',
+          zIndex: '3000'
+        }}
+      >
+        <div
+          hidden={!this.state.isExpanded}
+          style={{
+            backgroundColor: 'rgba(240,240,240,0.95)',
+            padding: '10px 20px'
+          }}
+        >
+          <h1>Export Data</h1>
+
+          <Button size="sm" outline onClick={this.onSelectExportNodes}>
+            Export Nodes
+          </Button>&nbsp;
+          <Button size="sm" outline onClick={this.onSelectExportEdges}>
+            Export Edges
+          </Button>&nbsp;
+          <i className="small text-muted">Export data in .csv format.</i>
+
+          <hr />
+
+          <h1>Import Data</h1>
+
+          <Button size="sm" outline onClick={this.onSelectExportNodes}>
+            Import Nodes
+          </Button>&nbsp;
+          <Button size="sm" outline onClick={this.onSelectExportNodes}>
+            Import Edges
+          </Button>&nbsp;
+          <i className="small text-muted">Import .csv data</i>
+        </div>
+      </div>
+    );
+  }
+
+} // class Help
+
+
+/// EXPORT REACT COMPONENT ////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+module.exports = ImportExport;

--- a/build/app/view/netcreate/components/ImportExport.jsx
+++ b/build/app/view/netcreate/components/ImportExport.jsx
@@ -50,45 +50,32 @@ class ImportExport extends UNISYS.Component {
   render() {
     return (
       <div
-        className="help"
         style={{
-          width: '50%',
-          maxWidth: '50%',
-          overflow: 'scroll',
-          position: 'fixed',
-          right: '10px',
-          zIndex: '3000'
+          backgroundColor: 'rgba(240,240,240,0.95)',
+          padding: '10px 20px'
         }}
       >
-        <div
-          hidden={!this.state.isExpanded}
-          style={{
-            backgroundColor: 'rgba(240,240,240,0.95)',
-            padding: '10px 20px'
-          }}
-        >
-          <h1>Export Data</h1>
+        <h1>Export Data</h1>
 
-          <Button size="sm" outline onClick={this.onSelectExportNodes}>
-            Export Nodes
-          </Button>&nbsp;
-          <Button size="sm" outline onClick={this.onSelectExportEdges}>
-            Export Edges
-          </Button>&nbsp;
-          <i className="small text-muted">Export data in .csv format.</i>
+        <Button size="sm" outline onClick={this.onSelectExportNodes}>
+          Export Nodes
+        </Button>&nbsp;
+        <Button size="sm" outline onClick={this.onSelectExportEdges}>
+          Export Edges
+        </Button>&nbsp;
+        <i className="small text-muted">Export data in .csv format.</i>
 
-          <hr />
+        <hr />
 
-          <h1>Import Data</h1>
+        <h1>Import Data</h1>
 
-          <Button size="sm" outline onClick={this.onSelectExportNodes}>
-            Import Nodes
-          </Button>&nbsp;
-          <Button size="sm" outline onClick={this.onSelectExportNodes}>
-            Import Edges
-          </Button>&nbsp;
-          <i className="small text-muted">Import .csv data</i>
-        </div>
+        <Button size="sm" outline disabled onClick={this.onSelectExportNodes}>
+          Import Nodes
+        </Button>&nbsp;
+        <Button size="sm" outline disabled onClick={this.onSelectExportNodes}>
+          Import Edges
+        </Button>&nbsp;
+        <i className="small text-muted">Import .csv data</i>
       </div>
     );
   }

--- a/build/app/view/netcreate/components/InfoPanel.jsx
+++ b/build/app/view/netcreate/components/InfoPanel.jsx
@@ -187,7 +187,7 @@ class InfoPanel extends UNISYS.Component {
             <NavItem>
               <NavLink
                 className={classnames({ active: activeTab === '3' })}
-                onClick={() => { this.toggle('4'); this.sendGA('Nodes Table', window.location); }}
+                onClick={() => { this.toggle('3'); this.sendGA('Nodes Table', window.location); }}
               >
                 Nodes Table
               </NavLink>
@@ -195,7 +195,7 @@ class InfoPanel extends UNISYS.Component {
             <NavItem>
               <NavLink
                 className={classnames({ active: activeTab === '4' })}
-                onClick={() => { this.toggle('5'); this.sendGA('Edges Table', window.location); }}
+                onClick={() => { this.toggle('4'); this.sendGA('Edges Table', window.location); }}
               >
                 Edges Table
               </NavLink>
@@ -203,7 +203,7 @@ class InfoPanel extends UNISYS.Component {
             <NavItem>
               <NavLink
                 className={classnames({ active: activeTab === '5' })}
-                onClick={() => { this.toggle('6'); this.sendGA('Vocabulary', window.location); }}
+                onClick={() => { this.toggle('5'); this.sendGA('Vocabulary', window.location); }}
               >
                 Vocabulary
               </NavLink>
@@ -211,7 +211,7 @@ class InfoPanel extends UNISYS.Component {
             <NavItem>
               <NavLink
                 className={classnames({ active: activeTab === '6' })}
-                onClick={() => { this.toggle('7'); this.sendGA('Help', window.location); }}
+                onClick={() => { this.toggle('6'); this.sendGA('Help', window.location); }}
               >
                 Help
               </NavLink>

--- a/build/app/view/netcreate/components/InfoPanel.jsx
+++ b/build/app/view/netcreate/components/InfoPanel.jsx
@@ -29,7 +29,6 @@ const ReactStrap = require('reactstrap');
 const { TabContent, TabPane, Nav, NavItem, NavLink, Row, Col, Button } = ReactStrap;
 const classnames = require('classnames');
 
-import FILTER from './filter/FilterEnums';
 const FiltersPanel = require('./filter/FiltersPanel');
 const NodeTable = require('./NodeTable');
 const EdgeTable = require('./EdgeTable');
@@ -182,20 +181,12 @@ class InfoPanel extends UNISYS.Component {
                 className={classnames({ active: activeTab === '2' })}
                 onClick={() => { this.toggle('2'); this.sendGA('Highlight', window.location); }}
               >
-                Highlight
+                Highlight / Filter
               </NavLink>
             </NavItem>
             <NavItem>
               <NavLink
                 className={classnames({ active: activeTab === '3' })}
-                onClick={() => { this.toggle('3'); this.sendGA('Filter', window.location); }}
-              >
-                Filter
-              </NavLink>
-            </NavItem>
-            <NavItem>
-              <NavLink
-                className={classnames({ active: activeTab === '4' })}
                 onClick={() => { this.toggle('4'); this.sendGA('Nodes Table', window.location); }}
               >
                 Nodes Table
@@ -203,7 +194,7 @@ class InfoPanel extends UNISYS.Component {
             </NavItem>
             <NavItem>
               <NavLink
-                className={classnames({ active: activeTab === '5' })}
+                className={classnames({ active: activeTab === '4' })}
                 onClick={() => { this.toggle('5'); this.sendGA('Edges Table', window.location); }}
               >
                 Edges Table
@@ -211,7 +202,7 @@ class InfoPanel extends UNISYS.Component {
             </NavItem>
             <NavItem>
               <NavLink
-                className={classnames({ active: activeTab === '6' })}
+                className={classnames({ active: activeTab === '5' })}
                 onClick={() => { this.toggle('6'); this.sendGA('Vocabulary', window.location); }}
               >
                 Vocabulary
@@ -219,7 +210,7 @@ class InfoPanel extends UNISYS.Component {
             </NavItem>
             <NavItem>
               <NavLink
-                className={classnames({ active: activeTab === '7' })}
+                className={classnames({ active: activeTab === '6' })}
                 onClick={() => { this.toggle('7'); this.sendGA('Help', window.location); }}
               >
                 Help
@@ -230,33 +221,30 @@ class InfoPanel extends UNISYS.Component {
             <TabPane tabId="1">
             </TabPane>
             <TabPane tabId="2">
-              <FiltersPanel tableHeight={tableHeight} filterAction={FILTER.ACTION.HIGHLIGHT}/>
+              <FiltersPanel tableHeight={tableHeight}/>
             </TabPane>
             <TabPane tabId="3">
-              <FiltersPanel tableHeight={tableHeight} filterAction={FILTER.ACTION.FILTER}/>
+              <Row>
+                <Col sm="12">
+                  {activeTab==="3" && <NodeTable tableHeight={tableHeight} bIgnoreTableUpdates={bIgnoreTableUpdates}/> }
+                </Col>
+              </Row>
             </TabPane>
             <TabPane tabId="4">
               <Row>
                 <Col sm="12">
-                  {activeTab==="4" && <NodeTable tableHeight={tableHeight} bIgnoreTableUpdates={bIgnoreTableUpdates}/> }
+                  {activeTab==="4" && <EdgeTable tableHeight={tableHeight} bIgnoreTableUpdates={bIgnoreTableUpdates} /> }
                 </Col>
               </Row>
             </TabPane>
             <TabPane tabId="5">
               <Row>
                 <Col sm="12">
-                  {activeTab==="5" && <EdgeTable tableHeight={tableHeight} bIgnoreTableUpdates={bIgnoreTableUpdates} /> }
-                </Col>
-              </Row>
-            </TabPane>
-            <TabPane tabId="6">
-              <Row>
-                <Col sm="12">
                   <Vocabulary tableHeight={tableHeight} />
                 </Col>
               </Row>
             </TabPane>
-            <TabPane tabId="7">
+            <TabPane tabId="6">
               <Row>
                 <Col sm="12">
                   <Help />
@@ -277,7 +265,7 @@ class InfoPanel extends UNISYS.Component {
         <div hidden={!hideDragger || filtersSummary===''}
           style={{ padding: '3px', fontSize: '0.8em', color:'#999', backgroundColor:'#eef'}}
         >
-          FILTERED BY: {filtersSummary} <Button size="sm" outline onClick={this.OnClearBtnClick}>Clear Filters</Button>
+          {filtersSummary} <Button size="sm" outline onClick={this.OnClearBtnClick}>Clear Filters</Button>
         </div>
       </div>
     );

--- a/build/app/view/netcreate/components/InfoPanel.jsx
+++ b/build/app/view/netcreate/components/InfoPanel.jsx
@@ -163,7 +163,7 @@ class InfoPanel extends UNISYS.Component {
       <div>
         <div id='tabpanel'
           style={{ height: tabpanelHeight, overflow: 'hidden', backgroundColor: '#eee'}}>
-          <Nav tabs className='nav-fill'>
+          <Nav tabs className=''>
             <NavItem>
               <NavLink
                 className={classnames({ active: activeTab === '1' })}

--- a/build/app/view/netcreate/components/InfoPanel.jsx
+++ b/build/app/view/netcreate/components/InfoPanel.jsx
@@ -29,7 +29,6 @@ const ReactStrap = require('reactstrap');
 const { TabContent, TabPane, Nav, NavItem, NavLink, Row, Col, Button } = ReactStrap;
 const classnames = require('classnames');
 
-const FiltersPanel = require('./filter/FiltersPanel');
 const NodeTable = require('./NodeTable');
 const EdgeTable = require('./EdgeTable');
 const Vocabulary = require('./Vocabulary');
@@ -178,14 +177,6 @@ class InfoPanel extends UNISYS.Component {
             </NavItem>
             <NavItem>
               <NavLink
-                className={classnames({ active: activeTab === '2' })}
-                onClick={() => { this.toggle('2'); this.sendGA('Highlight', window.location); }}
-              >
-                Highlight / Filter
-              </NavLink>
-            </NavItem>
-            <NavItem>
-              <NavLink
                 className={classnames({ active: activeTab === '3' })}
                 onClick={() => { this.toggle('3'); this.sendGA('Nodes Table', window.location); }}
               >
@@ -219,9 +210,6 @@ class InfoPanel extends UNISYS.Component {
           </Nav>
           <TabContent activeTab={activeTab} style={{height:'100%',overflow: 'hidden', backgroundColor: 'rgba(0,0,0,0.1)'}}>
             <TabPane tabId="1">
-            </TabPane>
-            <TabPane tabId="2">
-              <FiltersPanel tableHeight={tableHeight}/>
             </TabPane>
             <TabPane tabId="3">
               <Row>

--- a/build/app/view/netcreate/components/InfoPanel.jsx
+++ b/build/app/view/netcreate/components/InfoPanel.jsx
@@ -181,7 +181,7 @@ class InfoPanel extends UNISYS.Component {
                 className={classnames({ active: activeTab === '2' })}
                 onClick={() => { this.toggle('2'); this.sendGA('Filter', window.location); }}
               >
-                Filters
+                Highlight
               </NavLink>
             </NavItem>
             <NavItem>

--- a/build/app/view/netcreate/components/InfoPanel.jsx
+++ b/build/app/view/netcreate/components/InfoPanel.jsx
@@ -7,8 +7,7 @@
   * Filters
   * Nodes Table
   * Edges Table
-  * Vocabulary
-  * Help
+  * More -- Export/Import, Vocabulary, Help
 
   The panel itself can be resized vertically.
 
@@ -33,7 +32,6 @@ const classnames = require('classnames');
 
 const NodeTable = require('./NodeTable');
 const EdgeTable = require('./EdgeTable');
-const Vocabulary = require('./Vocabulary');
 const More = require('./More');
 
 /// REACT COMPONENT ///////////////////////////////////////////////////////////

--- a/build/app/view/netcreate/components/InfoPanel.jsx
+++ b/build/app/view/netcreate/components/InfoPanel.jsx
@@ -29,6 +29,7 @@ const ReactStrap = require('reactstrap');
 const { TabContent, TabPane, Nav, NavItem, NavLink, Row, Col, Button } = ReactStrap;
 const classnames = require('classnames');
 
+import FILTER from './filter/FilterEnums';
 const FiltersPanel = require('./filter/FiltersPanel');
 const NodeTable = require('./NodeTable');
 const EdgeTable = require('./EdgeTable');
@@ -179,7 +180,7 @@ class InfoPanel extends UNISYS.Component {
             <NavItem>
               <NavLink
                 className={classnames({ active: activeTab === '2' })}
-                onClick={() => { this.toggle('2'); this.sendGA('Filter', window.location); }}
+                onClick={() => { this.toggle('2'); this.sendGA('Highlight', window.location); }}
               >
                 Highlight
               </NavLink>
@@ -187,31 +188,39 @@ class InfoPanel extends UNISYS.Component {
             <NavItem>
               <NavLink
                 className={classnames({ active: activeTab === '3' })}
-                onClick={() => { this.toggle('3'); this.sendGA('Nodes Table', window.location); }}
+                onClick={() => { this.toggle('3'); this.sendGA('Filter', window.location); }}
+              >
+                Filter
+              </NavLink>
+            </NavItem>
+            <NavItem>
+              <NavLink
+                className={classnames({ active: activeTab === '4' })}
+                onClick={() => { this.toggle('4'); this.sendGA('Nodes Table', window.location); }}
               >
                 Nodes Table
               </NavLink>
             </NavItem>
             <NavItem>
               <NavLink
-                className={classnames({ active: activeTab === '4' })}
-                onClick={() => { this.toggle('4'); this.sendGA('Edges Table', window.location); }}
+                className={classnames({ active: activeTab === '5' })}
+                onClick={() => { this.toggle('5'); this.sendGA('Edges Table', window.location); }}
               >
                 Edges Table
               </NavLink>
             </NavItem>
             <NavItem>
               <NavLink
-                className={classnames({ active: activeTab === '5' })}
-                onClick={() => { this.toggle('5'); this.sendGA('Vocabulary', window.location); }}
+                className={classnames({ active: activeTab === '6' })}
+                onClick={() => { this.toggle('6'); this.sendGA('Vocabulary', window.location); }}
               >
                 Vocabulary
               </NavLink>
             </NavItem>
             <NavItem>
               <NavLink
-                className={classnames({ active: activeTab === '6' })}
-                onClick={() => { this.toggle('6'); this.sendGA('Help', window.location); }}
+                className={classnames({ active: activeTab === '7' })}
+                onClick={() => { this.toggle('7'); this.sendGA('Help', window.location); }}
               >
                 Help
               </NavLink>
@@ -221,30 +230,33 @@ class InfoPanel extends UNISYS.Component {
             <TabPane tabId="1">
             </TabPane>
             <TabPane tabId="2">
-              <FiltersPanel tableHeight={tableHeight} />
+              <FiltersPanel tableHeight={tableHeight} filterAction={FILTER.ACTION.HIGHLIGHT}/>
             </TabPane>
             <TabPane tabId="3">
-              <Row>
-                <Col sm="12">
-                  {activeTab==="3" && <NodeTable tableHeight={tableHeight} bIgnoreTableUpdates={bIgnoreTableUpdates}/> }
-                </Col>
-              </Row>
+              <FiltersPanel tableHeight={tableHeight} filterAction={FILTER.ACTION.FILTER}/>
             </TabPane>
             <TabPane tabId="4">
               <Row>
                 <Col sm="12">
-                  {activeTab==="4" && <EdgeTable tableHeight={tableHeight} bIgnoreTableUpdates={bIgnoreTableUpdates} /> }
+                  {activeTab==="4" && <NodeTable tableHeight={tableHeight} bIgnoreTableUpdates={bIgnoreTableUpdates}/> }
                 </Col>
               </Row>
             </TabPane>
             <TabPane tabId="5">
               <Row>
                 <Col sm="12">
-                  <Vocabulary tableHeight={tableHeight} />
+                  {activeTab==="5" && <EdgeTable tableHeight={tableHeight} bIgnoreTableUpdates={bIgnoreTableUpdates} /> }
                 </Col>
               </Row>
             </TabPane>
             <TabPane tabId="6">
+              <Row>
+                <Col sm="12">
+                  <Vocabulary tableHeight={tableHeight} />
+                </Col>
+              </Row>
+            </TabPane>
+            <TabPane tabId="7">
               <Row>
                 <Col sm="12">
                   <Help />

--- a/build/app/view/netcreate/components/InfoPanel.jsx
+++ b/build/app/view/netcreate/components/InfoPanel.jsx
@@ -81,14 +81,12 @@ class InfoPanel extends UNISYS.Component {
       if ((tab === `1`) || (tab === '6')) { // graph or help
         this.setState({
           tabpanelHeight: defaultTabPanelHeight, // show only tab buttons
-          hideDragger: true,
-          bIgnoreTableUpdates: true
+          hideDragger: true
         });
       } else {
         this.setState({
           tabpanelHeight: this.state.savedTabpanelHeight,
-          hideDragger: false,
-          bIgnoreTableUpdates: true
+          hideDragger: false
         });
       }
     } else {
@@ -97,8 +95,7 @@ class InfoPanel extends UNISYS.Component {
       this.setState({ activeTab: `1` });
       this.setState({
         tabpanelHeight: defaultTabPanelHeight, // show only tab buttons
-        hideDragger: true,
-        bIgnoreTableUpdates: true
+        hideDragger: true
       });
     }
   }
@@ -120,12 +117,10 @@ class InfoPanel extends UNISYS.Component {
     this.setState({
       tabpanelHeight: (top - this.state.tabpanelTop - 40) + 'px',
       tableHeight: (top - this.state.tabpanelTop) + 'px',
-      savedTabpanelHeight: (top - this.state.tabpanelTop - 40) + 'px',  // remember height when switching tabs
-      bIgnoreTableUpdates: true // ignore this update at the table level if it is a large data set
+      savedTabpanelHeight: (top - this.state.tabpanelTop - 40) + 'px'  // remember height when switching tabs
     });
   }
   endDrag() {
-    this.setState({bIgnoreTableUpdates: false})
     document.onmouseup = null;
     document.onmousemove = null;
   }
@@ -162,7 +157,9 @@ class InfoPanel extends UNISYS.Component {
   /*/
   /*/
   render() {
-    let { activeTab, tabpanelHeight, tableHeight, hideDragger, draggerTop, bIgnoreTableUpdates, filtersSummary} = this.state;
+    const {
+      activeTab, tabpanelHeight, tableHeight, hideDragger, draggerTop, filtersSummary
+    } = this.state;
     //send flag in with tableheight
     return (
       <div>
@@ -208,14 +205,14 @@ class InfoPanel extends UNISYS.Component {
             <TabPane tabId="3">
               <Row>
                 <Col sm="12">
-                  {activeTab==="3" && <NodeTable tableHeight={tableHeight} bIgnoreTableUpdates={bIgnoreTableUpdates}/> }
+                  {activeTab==="3" && <NodeTable tableHeight={tableHeight} /> }
                 </Col>
               </Row>
             </TabPane>
             <TabPane tabId="4">
               <Row>
                 <Col sm="12">
-                  {activeTab==="4" && <EdgeTable tableHeight={tableHeight} bIgnoreTableUpdates={bIgnoreTableUpdates} /> }
+                  {activeTab==="4" && <EdgeTable tableHeight={tableHeight} /> }
                 </Col>
               </Row>
             </TabPane>

--- a/build/app/view/netcreate/components/InfoPanel.jsx
+++ b/build/app/view/netcreate/components/InfoPanel.jsx
@@ -251,9 +251,9 @@ class InfoPanel extends UNISYS.Component {
         ></div>
 
         <div hidden={!hideDragger || filtersSummary===''}
-          style={{ padding: '3px', fontSize: '0.8em', color:'#999', backgroundColor:'#eef'}}
+          style={{ padding: '3px 5px', fontSize: '0.8em', textAlign: 'right', color:'#fff', backgroundColor:'#3339'}}
         >
-          {filtersSummary} <Button size="sm" outline onClick={this.OnClearBtnClick}>Clear Filters</Button>
+          {filtersSummary}&nbsp;<Button size="sm" outline onClick={this.OnClearBtnClick} style={{ color: '#eee', borderColor: '#ddd', fontSize: '0.8em', padding: '0.1rem 0.2rem' }}>Clear Filters</Button>
         </div>
       </div>
     );

--- a/build/app/view/netcreate/components/InfoPanel.jsx
+++ b/build/app/view/netcreate/components/InfoPanel.jsx
@@ -18,6 +18,8 @@
 var DBG = false;
 var UDATA = null;
 
+const defaultTabPanelHeight = '42px'; // show only tab buttons, no gap
+
 /// UNISYS INITIALIZE REQUIRES for REACT ROOT /////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const UNISYS = require('unisys/client');
@@ -46,7 +48,7 @@ class InfoPanel extends UNISYS.Component {
       tabpanelTop: '0',
       draggerMouseOffsetY: '0',   // Mouse click position inside dragger
                                   // Allows user to grab dragger from the middle
-      tabpanelHeight: '50px',
+      tabpanelHeight: defaultTabPanelHeight,
       tableHeight: '350px',
       savedTabpanelHeight: '350px',
       draggerTop: 'inherit',
@@ -78,7 +80,7 @@ class InfoPanel extends UNISYS.Component {
       this.setState({ activeTab: tab });
       if ((tab === `1`) || (tab === '6')) { // graph or help
         this.setState({
-          tabpanelHeight: '50px', // show only tab buttons
+          tabpanelHeight: defaultTabPanelHeight, // show only tab buttons
           hideDragger: true,
           bIgnoreTableUpdates: true
         });
@@ -94,7 +96,7 @@ class InfoPanel extends UNISYS.Component {
       // so select tab 1
       this.setState({ activeTab: `1` });
       this.setState({
-        tabpanelHeight: '50px', // show only tab buttons
+        tabpanelHeight: defaultTabPanelHeight, // show only tab buttons
         hideDragger: true,
         bIgnoreTableUpdates: true
       });
@@ -166,7 +168,7 @@ class InfoPanel extends UNISYS.Component {
       <div>
         <div id='tabpanel'
           style={{ height: tabpanelHeight, overflow: 'hidden', backgroundColor: '#eee'}}>
-          <Nav tabs>
+          <Nav tabs className='nav-fill'>
             <NavItem>
               <NavLink
                 className={classnames({ active: activeTab === '1' })}
@@ -189,14 +191,6 @@ class InfoPanel extends UNISYS.Component {
                 onClick={() => { this.toggle('4'); this.sendGA('Edges Table', window.location); }}
               >
                 Edges Table
-              </NavLink>
-            </NavItem>
-            <NavItem>
-              <NavLink
-                className={classnames({ active: activeTab === '5' })}
-                onClick={() => { this.toggle('5'); this.sendGA('Vocabulary', window.location); }}
-              >
-                Vocabulary
               </NavLink>
             </NavItem>
             <NavItem>
@@ -225,19 +219,8 @@ class InfoPanel extends UNISYS.Component {
                 </Col>
               </Row>
             </TabPane>
-            <TabPane tabId="5">
-              <Row>
-                <Col sm="12">
-                  <Vocabulary tableHeight={tableHeight} />
-                </Col>
-              </Row>
-            </TabPane>
             <TabPane tabId="6">
-              <Row>
-                <Col sm="12">
-                  <More />
-                </Col>
-              </Row>
+              <More />
             </TabPane>
           </TabContent>
         </div>

--- a/build/app/view/netcreate/components/InfoPanel.jsx
+++ b/build/app/view/netcreate/components/InfoPanel.jsx
@@ -32,7 +32,7 @@ const classnames = require('classnames');
 const NodeTable = require('./NodeTable');
 const EdgeTable = require('./EdgeTable');
 const Vocabulary = require('./Vocabulary');
-const Help = require('./Help');
+const More = require('./More');
 
 /// REACT COMPONENT ///////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -204,7 +204,7 @@ class InfoPanel extends UNISYS.Component {
                 className={classnames({ active: activeTab === '6' })}
                 onClick={() => { this.toggle('6'); this.sendGA('Help', window.location); }}
               >
-                Help
+                More...
               </NavLink>
             </NavItem>
           </Nav>
@@ -235,7 +235,7 @@ class InfoPanel extends UNISYS.Component {
             <TabPane tabId="6">
               <Row>
                 <Col sm="12">
-                  <Help />
+                  <More />
                 </Col>
               </Row>
             </TabPane>

--- a/build/app/view/netcreate/components/InfoPanel.jsx
+++ b/build/app/view/netcreate/components/InfoPanel.jsx
@@ -18,7 +18,7 @@
 var DBG = false;
 var UDATA = null;
 
-const defaultTabPanelHeight = '42px'; // show only tab buttons, no gap
+const defaultTabPanelHeight = 42; // show only tab buttons, no gap
 
 /// UNISYS INITIALIZE REQUIRES for REACT ROOT /////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -48,8 +48,8 @@ class InfoPanel extends UNISYS.Component {
       tabpanelTop: '0',
       draggerMouseOffsetY: '0',   // Mouse click position inside dragger
                                   // Allows user to grab dragger from the middle
-      tabpanelHeight: defaultTabPanelHeight,
-      tableHeight: '350px',
+      tabpanelHeight: `${defaultTabPanelHeight}px`,
+      tableHeight: '308px', // 350 - defaultTabPanelHeight
       savedTabpanelHeight: '350px',
       draggerTop: 'inherit',
       hideDragger: true,
@@ -80,7 +80,7 @@ class InfoPanel extends UNISYS.Component {
       this.setState({ activeTab: tab });
       if ((tab === `1`) || (tab === '6')) { // graph or help
         this.setState({
-          tabpanelHeight: defaultTabPanelHeight, // show only tab buttons
+          tabpanelHeight: `${defaultTabPanelHeight}px`, // show only tab buttons
           hideDragger: true
         });
       } else {
@@ -94,7 +94,7 @@ class InfoPanel extends UNISYS.Component {
       // so select tab 1
       this.setState({ activeTab: `1` });
       this.setState({
-        tabpanelHeight: defaultTabPanelHeight, // show only tab buttons
+        tabpanelHeight: `${defaultTabPanelHeight}px`, // show only tab buttons
         hideDragger: true
       });
     }
@@ -111,12 +111,12 @@ class InfoPanel extends UNISYS.Component {
   }
   handleDrag(e) {
     e.stopPropagation();
-    // limit to 120 to keep from dragging up past the tabpanel
-    // 120 = navbar + tabpanel height
-    let top = Math.max(120, e.clientY + this.state.draggerMouseOffsetY);
+    // limit to 122 to keep from dragging up past the tabpanel
+    // 122 = navbar + tabpanel height
+    let top = Math.max(122, e.clientY + this.state.draggerMouseOffsetY + defaultTabPanelHeight);
     this.setState({
       tabpanelHeight: (top - this.state.tabpanelTop - 40) + 'px',
-      tableHeight: (top - this.state.tabpanelTop) + 'px',
+      tableHeight: (top - this.state.tabpanelTop - 40 - defaultTabPanelHeight) + 'px',
       savedTabpanelHeight: (top - this.state.tabpanelTop - 40) + 'px'  // remember height when switching tabs
     });
   }

--- a/build/app/view/netcreate/components/More.jsx
+++ b/build/app/view/netcreate/components/More.jsx
@@ -1,0 +1,151 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  ## OVERVIEW
+
+  "More" displays:
+  * Export/Import
+  * Help
+  * Vocabulary
+
+
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+var DBG = false;
+var UDATA = null;
+
+/// LIBRARIES /////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const React        = require('react');
+const ReactStrap   = require('reactstrap');
+const { TabContent, TabPane, Nav, NavItem, NavLink, Row, Col, Button } = ReactStrap;
+const classnames = require('classnames');
+const Help = require('./Help');
+const Vocabulary = require('./Vocabulary');
+const ImportExport = require('./ImportExport');
+
+const UNISYS   = require('unisys/client');
+
+
+/// REACT COMPONENT ///////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// export a class object for consumption by brunch/require
+class More extends UNISYS.Component {
+  constructor (props) {
+    super(props);
+    this.state = {
+      isExpanded: true,
+      activeTab: '1'
+    };
+    this.toggleTab = this.toggleTab.bind(this);
+    this.onToggleExpanded = this.onToggleExpanded.bind(this);
+
+    UDATA = UNISYS.NewDataLink(this);
+  } // constructor
+
+
+  /// UI EVENT HANDLERS /////////////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  toggleTab(tab) {
+    window.event.stopPropagation();
+    if (this.state.activeTab !== tab) {
+      this.setState({ activeTab: tab });
+    }
+  }
+
+  onToggleExpanded(event) {
+    this.setState({
+      isExpanded: !this.state.isExpanded
+    })
+  }
+
+/// REACT LIFECYCLE METHODS ///////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/ This is not yet implemented as of React 16.2.  It's implemented in 16.3.
+    getDerivedStateFromProps (props, state) {
+      console.error('getDerivedStateFromProps!!!');
+    }
+/*/
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  render() {
+    const { activeTab } = this.state;
+
+    return (
+      <div className="help"
+        style={{
+          overflow: 'scroll',
+          position: 'fixed',
+          right: '10px',
+          width: '50%',
+          zIndex: '3000'
+        }}
+      >
+        <Button size="sm" outline hidden
+          style={{float:'right'}}
+          onClick={this.onToggleExpanded}
+        >{this.state.isExpanded ? "Hide Help" : "Help"}</Button>
+        <div hidden={!this.state.isExpanded}
+          style={{backgroundColor:'rgba(240,240,240,0.95)',padding:'10px'}}>
+          <div id='tabpanel'
+            style={{ overflow: 'hidden', backgroundColor: '#eee'}}>
+            <Nav tabs>
+              <NavItem>
+                <NavLink
+                  className={classnames({ active: activeTab === '1' })}
+                  onClick={() => { this.toggleTab('1') } }
+                >
+                  Help
+                </NavLink>
+              </NavItem>
+              <NavItem>
+                <NavLink
+                  className={classnames({ active: activeTab === '2' })}
+                  onClick={() => { this.toggleTab('2') }}
+                >
+                  Vocabulary
+                </NavLink>
+              </NavItem>
+              <NavItem>
+                <NavLink
+                  className={classnames({ active: activeTab === '3' })}
+                  onClick={() => { this.toggleTab('3') }}
+                >
+                  Import / Export
+                </NavLink>
+              </NavItem>
+            </Nav>
+          </div>
+          <TabContent activeTab={activeTab} style={{height:'100%',overflow: 'hidden', backgroundColor: 'rgba(0,0,0,0.1)'}}>
+            <TabPane tabId="1">
+              <Row>
+                <Col sm="12">
+                  {activeTab==="1" && <Help /> }
+                </Col>
+              </Row>
+            </TabPane>
+            <TabPane tabId="2">
+              <Row>
+                <Col sm="12">
+                  {activeTab==="2" && <Vocabulary /> }
+                </Col>
+              </Row>
+            </TabPane>
+            <TabPane tabId="3">
+              <Row>
+                <Col sm="12">
+                  {activeTab==="3" && <ImportExport /> }
+                </Col>
+              </Row>
+            </TabPane>
+          </TabContent>
+        </div>
+      </div>
+    );
+  }
+
+} // class Help
+
+
+/// EXPORT REACT COMPONENT ////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+module.exports = More;

--- a/build/app/view/netcreate/components/More.jsx
+++ b/build/app/view/netcreate/components/More.jsx
@@ -38,7 +38,6 @@ class More extends UNISYS.Component {
       activeTab: '1'
     };
     this.toggleTab = this.toggleTab.bind(this);
-    this.onToggleExpanded = this.onToggleExpanded.bind(this);
 
     UDATA = UNISYS.NewDataLink(this);
   } // constructor
@@ -51,12 +50,6 @@ class More extends UNISYS.Component {
     if (this.state.activeTab !== tab) {
       this.setState({ activeTab: tab });
     }
-  }
-
-  onToggleExpanded(event) {
-    this.setState({
-      isExpanded: !this.state.isExpanded
-    })
   }
 
 /// REACT LIFECYCLE METHODS ///////////////////////////////////////////////////
@@ -73,21 +66,24 @@ class More extends UNISYS.Component {
     return (
       <div className="help"
         style={{
-          overflow: 'scroll',
           position: 'fixed',
           right: '10px',
           width: '50%',
-          zIndex: '3000'
+          height: '90%',
+          overflow: 'hidden',
+          zIndex: '3000',
+          padding: '10px',
+          backgroundColor: '#fff', // match tab
+          border: '1px solid #999',
+          borderTop: 'none'
         }}
       >
-        <Button size="sm" outline hidden
-          style={{float:'right'}}
-          onClick={this.onToggleExpanded}
-        >{this.state.isExpanded ? "Hide Help" : "Help"}</Button>
-        <div hidden={!this.state.isExpanded}
-          style={{backgroundColor:'rgba(240,240,240,0.95)',padding:'10px'}}>
-          <div id='tabpanel'
-            style={{ overflow: 'hidden', backgroundColor: '#eee'}}>
+        <div style={{
+          height: '100%',
+          overflow: 'hidden',
+          padding: '10px'
+        }}>
+          <div id='tabpanel' >
             <Nav tabs>
               <NavItem>
                 <NavLink
@@ -115,27 +111,18 @@ class More extends UNISYS.Component {
               </NavItem>
             </Nav>
           </div>
-          <TabContent activeTab={activeTab} style={{height:'100%',overflow: 'hidden', backgroundColor: 'rgba(0,0,0,0.1)'}}>
+          <TabContent activeTab={activeTab} style={{
+            height: '100%',
+            overflow: 'scroll'
+          }}>
             <TabPane tabId="1">
-              <Row>
-                <Col sm="12">
-                  {activeTab==="1" && <Help /> }
-                </Col>
-              </Row>
+              {activeTab==="1" && <Help /> }
             </TabPane>
             <TabPane tabId="2">
-              <Row>
-                <Col sm="12">
-                  {activeTab==="2" && <Vocabulary /> }
-                </Col>
-              </Row>
+              {activeTab==="2" && <Vocabulary /> }
             </TabPane>
             <TabPane tabId="3">
-              <Row>
-                <Col sm="12">
-                  {activeTab==="3" && <ImportExport /> }
-                </Col>
-              </Row>
+              {activeTab==="3" && <ImportExport /> }
             </TabPane>
           </TabContent>
         </div>

--- a/build/app/view/netcreate/components/NetGraph.jsx
+++ b/build/app/view/netcreate/components/NetGraph.jsx
@@ -106,9 +106,9 @@ class NetGraph extends UNISYS.Component {
             </div>
           </div>
           <div style={{ position: 'absolute', right: '10px', width: '50px', zIndex:1001 }}>
-            <Button outline onClick={this.onZoomIn} style={{width:'35px'}}>+</Button>&nbsp;
-            <Button outline onClick={this.onZoomReset} style={{ width: '35px' }}>&bull;</Button>&nbsp;
-            <Button outline onClick={this.onZoomOut} style={{ width: '35px' }}>-</Button>
+            <Button outline onClick={this.onZoomIn} style={{ width:'35px', backgroundColor: '#fff', opacity: '0.8' }}>+</Button>&nbsp;
+            <Button outline onClick={this.onZoomReset} style={{ width: '35px', backgroundColor: '#fff', opacity: '0.8'  }}>&bull;</Button>&nbsp;
+            <Button outline onClick={this.onZoomOut} style={{ width: '35px', backgroundColor: '#fff', opacity: '0.8'  }}>-</Button>
           </div>
           <div style={{ position: 'absolute', bottom: '40px', marginLeft: '10px', marginBottom: '15px',fontSize: '10px' }}>
 

--- a/build/app/view/netcreate/components/NetGraph.jsx
+++ b/build/app/view/netcreate/components/NetGraph.jsx
@@ -80,7 +80,6 @@ class NetGraph extends UNISYS.Component {
       let el = ReactDOM.findDOMNode(this);
       let d3NetGraph = new D3NetGraph(el, this.AppState('TEMPLATE').nodePrompts);
       this.setState({ d3NetGraph });
-
     }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/

--- a/build/app/view/netcreate/components/NodeSelector.jsx
+++ b/build/app/view/netcreate/components/NodeSelector.jsx
@@ -924,7 +924,7 @@ class NodeSelector extends UNISYS.Component {
       }
         return (
         <div>
-          <FormGroup className="text-right" style={{marginTop:'-35px',paddingRight:'5px'}}>
+          <FormGroup className="text-right" style={{marginTop:'-20px',paddingRight:'5px'}}>
             <Button outline size="sm"
               hidden={this.state.isLocked || this.state.isEditable}
               onClick={this.onNewNodeButtonClick}
@@ -1085,10 +1085,6 @@ class NodeSelector extends UNISYS.Component {
               >Add New Edge</Button>
             </FormGroup>
           </div>
-
-
-
-
         </div>
 
       )

--- a/build/app/view/netcreate/components/NodeTable.jsx
+++ b/build/app/view/netcreate/components/NodeTable.jsx
@@ -331,16 +331,16 @@ class NodeTable extends UNISYS.Component {
 /*/
 render() {
   if (this.state.nodes === undefined) return "";
-  let { nodePrompts } = this.state;
-  let { tableHeight } = this.props;
-  let styles = `thead, tbody { font-size: 0.8em }
+  const { nodePrompts } = this.state;
+  const { tableHeight } = this.props;
+  const styles = `thead, tbody { font-size: 0.8em }
                 thead { position: relative; }
                 tbody { overflow: auto; }
                 .btn-sm { font-size: 0.6rem; padding: 0.1rem 0.2rem }
                 `
   return (
     <div style={{overflow:'auto',
-      position:'relative',display: 'block', left: '1px', right:'10px',maxHeight: tableHeight, backgroundColor:'#eafcff'
+      position:'relative',display: 'block', left: '1px', right:'10px', maxHeight: tableHeight, backgroundColor:'#eafcff'
     }}>
       <style>{styles}</style>
       <Button size="sm" outline hidden

--- a/build/app/view/netcreate/components/NodeTable.jsx
+++ b/build/app/view/netcreate/components/NodeTable.jsx
@@ -339,45 +339,46 @@ render() {
   if (this.state.nodes === undefined) return "";
   let { nodePrompts } = this.state;
   let { tableHeight } = this.props;
-  let styles = `thead, tbody {  }
+  let styles = `thead, tbody { font-size: 0.8em }
                 thead { position: relative; }
                 tbody { overflow: auto; }
+                .btn-sm { font-size: 0.6rem; padding: 0.1rem 0.2rem }
                 `
   return (
-      <div style={{overflow:'auto',
-                  position:'relative',display: 'block', left: '1px', right:'10px',maxHeight: tableHeight, backgroundColor:'#eafcff'
-      }}>
+    <div style={{overflow:'auto',
+      position:'relative',display: 'block', left: '1px', right:'10px',maxHeight: tableHeight, backgroundColor:'#eafcff'
+    }}>
       <style>{styles}</style>
       <Button size="sm" outline hidden
         onClick={this.onToggleExpanded}
       >{this.state.isExpanded ? "Hide Node Table" : "Show Node Table"}</Button>
       <Table hidden={!this.state.isExpanded} hover size="sm"
-              responsive striped
-              className="nodetable w-auto"
+        responsive striped
+        className="nodetable w-auto"
       >
         <thead>
           <tr>
             <th width="4%"><div style={{color: '#f3f3ff'}}>_Edit_</div></th>
-            <th hidden={!DBG}>ID</th>
-            <th width="12%"><Button size="sm"
+            <th width="4%" hidden={!DBG}>ID</th>
+            <th width="4%"><Button size="sm"
                   onClick={() => this.setSortKey("edgeCount")}
                 >{nodePrompts.degrees.label} {this.sortSymbol("edgeCount")}</Button></th>
             <th width="15%"><Button size="sm"
                   onClick={()=>this.setSortKey("label")}
                 >{nodePrompts.label.label} {this.sortSymbol("label")}</Button></th>
-            <th width="15%"hidden={nodePrompts.type.hidden}>
+            <th width="10%"hidden={nodePrompts.type.hidden}>
                 <Button size="sm"
                   onClick={()=>this.setSortKey("type")}
                 >{nodePrompts.type.label} {this.sortSymbol("type")}</Button></th>
-            <th width="26%"hidden={nodePrompts.info.hidden}>
+            <th width="20%"hidden={nodePrompts.info.hidden}>
                 <Button size="sm"
                   onClick={()=>this.setSortKey("info")}
                 >{nodePrompts.info.label} {this.sortSymbol("info")}</Button></th>
-            <th width="26%" hidden={nodePrompts.notes.hidden}>
+            <th width="30%" hidden={nodePrompts.notes.hidden}>
                 <Button size="sm"
                   onClick={()=>this.setSortKey("notes")}
                 >{nodePrompts.notes.label} {this.sortSymbol("notes")}</Button></th>
-            <th  width="20%"hidden={!isLocalHost}><Button size="sm"
+            <th  width="10%"hidden={!isLocalHost}><Button size="sm"
                   onClick={()=>this.setSortKey("Updated")}
                 >Updated {this.sortSymbol("Updated")}</Button></th>
           </tr>

--- a/build/app/view/netcreate/components/NodeTable.jsx
+++ b/build/app/view/netcreate/components/NodeTable.jsx
@@ -35,7 +35,7 @@ const isLocalHost  = (SETTINGS.EJSProp('client').ip === '127.0.0.1') || (locatio
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const React        = require('react');
 const ReactStrap   = require('reactstrap');
-const { Button, Table }    = ReactStrap;
+const { Button }    = ReactStrap;
 const MarkdownNote = require('./MarkdownNote');
 const UNISYS   = require('unisys/client');
 var   UDATA    = null;
@@ -334,20 +334,20 @@ render() {
   const { nodePrompts } = this.state;
   const { tableHeight } = this.props;
   const styles = `thead, tbody { font-size: 0.8em }
-                .table {
-                  display: table; /* override bootstrap for fixed header */
-                  border-spacing: 0;
-                 }
-                .table th {
-                  position: -webkit-sticky;
-                  position: sticky;
-                  top: 0;
-                  background-color: #eafcff;
-                  border-top: none;
-                }
-                xtbody { overflow: auto; }
-                .btn-sm { font-size: 0.6rem; padding: 0.1rem 0.2rem }
-                `
+                  .table {
+                    display: table; /* override bootstrap for fixed header */
+                    border-spacing: 0;
+                  }
+                  .table th {
+                    position: -webkit-sticky;
+                    position: sticky;
+                    top: 0;
+                    background-color: #eafcff;
+                    border-top: none;
+                  }
+                  xtbody { overflow: auto; }
+                  .btn-sm { font-size: 0.6rem; padding: 0.1rem 0.2rem }
+                  `
   return (
     <div style={{
       overflow: 'auto',

--- a/build/app/view/netcreate/components/NodeTable.jsx
+++ b/build/app/view/netcreate/components/NodeTable.jsx
@@ -334,21 +334,35 @@ render() {
   const { nodePrompts } = this.state;
   const { tableHeight } = this.props;
   const styles = `thead, tbody { font-size: 0.8em }
-                thead { position: relative; }
-                tbody { overflow: auto; }
+                .table {
+                  display: table; /* override bootstrap for fixed header */
+                  border-spacing: 0;
+                 }
+                .table th {
+                  position: -webkit-sticky;
+                  position: sticky;
+                  top: 0;
+                  background-color: #eafcff;
+                  border-top: none;
+                }
+                xtbody { overflow: auto; }
                 .btn-sm { font-size: 0.6rem; padding: 0.1rem 0.2rem }
                 `
   return (
-    <div style={{overflow:'auto',
-      position:'relative',display: 'block', left: '1px', right:'10px', maxHeight: tableHeight, backgroundColor:'#eafcff'
+    <div style={{
+      overflow: 'auto',
+      position: 'relative',
+      display: 'block',
+      left: '1px', right: '10px',
+      height: tableHeight,
+      backgroundColor: '#eafcff'
     }}>
       <style>{styles}</style>
-      <Button size="sm" outline hidden
-        onClick={this.onToggleExpanded}
-      >{this.state.isExpanded ? "Hide Node Table" : "Show Node Table"}</Button>
-      <Table hidden={!this.state.isExpanded} hover size="sm"
-        responsive striped
-        className="nodetable w-auto"
+      <table hidden={!this.state.isExpanded}
+        // size="sm" hover responsive striped // ReactStrap properties
+        // Need to use a standard 'table' not ReactStrap so that we can set
+        // the container div height and support non-scrolling headers
+        className="table table-striped table-responsive table-hover table-sm nodetable w-auto"
       >
         <thead>
           <tr>
@@ -402,7 +416,7 @@ render() {
           </tr>
         ))}
         </tbody>
-      </Table>
+      </table>
     </div>
   );
 

--- a/build/app/view/netcreate/components/NodeTable.jsx
+++ b/build/app/view/netcreate/components/NodeTable.jsx
@@ -66,7 +66,7 @@ class NodeTable extends UNISYS.Component {
     this.setSortKey = this.setSortKey.bind(this);
     this.sortSymbol = this.sortSymbol.bind(this);
 
-    this.sortDirection = -1;
+    this.sortDirection = 1; // alphabetical A-Z
 
     /// Initialize UNISYS DATA LINK for REACT
     UDATA = UNISYS.NewDataLink(this);
@@ -268,7 +268,7 @@ class NodeTable extends UNISYS.Component {
       if(key != this.state.sortkey) // this is not the current sort, so don't show anything
         return "";
       else
-        return this.sortDirection==-1?"▼":"▲"; // default to "decreasing" and flip if clicked again
+        return this.sortDirection==1?"▼":"▲"; // default to "decreasing" and flip if clicked again
     }
 
 

--- a/build/app/view/netcreate/components/NodeTable.jsx
+++ b/build/app/view/netcreate/components/NodeTable.jsx
@@ -49,7 +49,6 @@ class NodeTable extends UNISYS.Component {
     this.state = {
       nodePrompts: this.AppState('TEMPLATE').nodePrompts,
       nodes: [],
-      // edgeCounts: {},         // {nodeID:count,...}
       filteredNodes: [],
       isExpanded: true,
       sortkey: 'label'
@@ -138,7 +137,6 @@ class NodeTable extends UNISYS.Component {
     // {}
 
     if (data.nodes) {
-      // const edgeCounts = this.countEdges(data.edges);
       const nodes = this.sortTable(this.state.sortkey, data.nodes);
       this.setState({
         nodes: nodes,
@@ -172,7 +170,6 @@ class NodeTable extends UNISYS.Component {
 /*/
 /*/ sortByEdgeCount(nodes) {
       if (nodes) {
-        // let edgeCounts = this.state.edgeCounts;
         return nodes.sort( (a, b) => {
             let akey = a.degrees || 0,
               bkey = b.degrees || 0;

--- a/build/app/view/netcreate/components/NodeTable.jsx
+++ b/build/app/view/netcreate/components/NodeTable.jsx
@@ -153,18 +153,6 @@ class NodeTable extends UNISYS.Component {
   }
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/*/ Build table of counts
-/*/
-// JD removed because "size" seemed to work just fine? (I added a degrees that is size - 1)
-countEdges(edges) {
-  let edgeCounts = {}; // this.state.edgeCounts;
-  edges.forEach(edge => {
-    edgeCounts[edge.source.id] = edgeCounts[edge.source.id] !== undefined ? edgeCounts[edge.source.id] + 1 : 1;
-    edgeCounts[edge.target.id] = edgeCounts[edge.target.id] !== undefined ? edgeCounts[edge.target.id] + 1 : 1;
-  });
-  return edgeCounts;
-}
-
 
 /// UTILITIES /////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/build/app/view/netcreate/components/NodeTable.jsx
+++ b/build/app/view/netcreate/components/NodeTable.jsx
@@ -109,13 +109,12 @@ class NodeTable extends UNISYS.Component {
     displayUpdated(nodeEdge) {
       var d = new Date(nodeEdge.meta.revision > 0 ? nodeEdge.meta.updated : nodeEdge.meta.created);
 
-      var year = "" + d.getFullYear();
+      var year = String(d.getFullYear());
       var date = (d.getMonth()+1)+"/"+d.getDate()+"/"+ year.substr(2,4);
       var time = d.toTimeString().substr(0,5);
       var dateTime = date+' at '+time;
       var titleString = "v" + nodeEdge.meta.revision;
-      if(nodeEdge._nlog)
-        titleString += " by " + nodeEdge._nlog[nodeEdge._nlog.length-1];
+      if (nodeEdge._nlog) titleString += " by " + nodeEdge._nlog[nodeEdge._nlog.length-1];
       var tag = <span title={titleString}> {dateTime} </span>;
 
       return tag;
@@ -172,11 +171,12 @@ class NodeTable extends UNISYS.Component {
         return nodes.sort( (a,b) => {
           let akey = a.id,
               bkey = b.id;
-          if (akey<bkey) return -1*this.sortDirection;
-          if (akey>bkey) return 1*this.sortDirection;
+          if (akey<bkey) return -1*Number(this.sortDirection);
+          if (akey>bkey) return 1*Number(this.sortDirection);
           return 0;
         });
       }
+      return 0;
     }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/
@@ -186,11 +186,12 @@ class NodeTable extends UNISYS.Component {
             let akey = a.degrees || 0,
               bkey = b.degrees || 0;
           // sort descending
-          if (akey > bkey) return 1*this.sortDirection;
-          if (akey < bkey) return -1*this.sortDirection;
+          if (akey > bkey) return 1*Number(this.sortDirection);
+          if (akey < bkey) return -1*Number(this.sortDirection);
           return 0;
         });
       }
+      return 0;
     }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/
@@ -202,6 +203,7 @@ class NodeTable extends UNISYS.Component {
           return (akey.localeCompare(bkey)*this.sortDirection);
         });
       }
+      return 0;
     }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/
@@ -210,23 +212,23 @@ class NodeTable extends UNISYS.Component {
         return nodes.sort( (a,b) => {
           let akey = a.attributes[key],
               bkey = b.attributes[key];
-          if (akey<bkey) return -1*this.sortDirection;
-          if (akey>bkey) return 1*this.sortDirection;
+          if (akey<bkey) return -1*Number(this.sortDirection);
+          if (akey>bkey) return 1*Number(this.sortDirection);
           return 0;
         });
       }
+      return 0;
     }
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/
-/*/ sortByUpdated(nodes)
-    {
+/*/ sortByUpdated(nodes) {
       if (nodes) {
         return nodes.sort( (a,b) => {
           let akey = (a.meta.revision > 0 ? a.meta.updated : a.meta.created),
               bkey = (b.meta.revision > 0 ? b.meta.updated : b.meta.created);
-          if (akey<bkey) return -1*this.sortDirection;
-          if (akey>bkey) return 1*this.sortDirection;
+          if (akey<bkey) return -1*Number(this.sortDirection);
+          if (akey>bkey) return 1*Number(this.sortDirection);
           return 0;
         });
       }
@@ -263,12 +265,9 @@ class NodeTable extends UNISYS.Component {
       }
     }
 
-    sortSymbol(key)
-    {
-      if(key != this.state.sortkey) // this is not the current sort, so don't show anything
-        return "";
-      else
-        return this.sortDirection==1?"▼":"▲"; // default to "decreasing" and flip if clicked again
+    sortSymbol(key) {
+      if (key !== this.state.sortkey) return ""; // this is not the current sort, so don't show anything
+      else  return this.sortDirection === 1?"▼":"▲"; // default to "decreasing" and flip if clicked again
     }
 
 
@@ -300,10 +299,8 @@ class NodeTable extends UNISYS.Component {
 /*/
 /*/ setSortKey (key) {
 
-      if(key == this.state.sortkey)
-        this.sortDirection = (-1 * this.sortDirection);// if this was already the key, flip the direction
-      else
-          this.sortDirection = 1;
+      if (key === this.state.sortkey) this.sortDirection = (-1 * this.sortDirection);// if this was already the key, flip the direction
+      else this.sortDirection = 1;
 
       const nodes = this.sortTable(key, this.state.nodes);
       this.setState({ sortkey: key, nodes });

--- a/build/app/view/netcreate/components/NodeTable.jsx
+++ b/build/app/view/netcreate/components/NodeTable.jsx
@@ -25,7 +25,7 @@
 
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
 
-var DBG = true;
+var DBG = false;
 
 const SETTINGS     = require('settings');
 const isLocalHost  = (SETTINGS.EJSProp('client').ip === '127.0.0.1') || (location.href.includes('admin=true'));

--- a/build/app/view/netcreate/components/NodeTable.jsx
+++ b/build/app/view/netcreate/components/NodeTable.jsx
@@ -172,8 +172,9 @@ countEdges(edges) {
       }
     }
 
-    /// ---
-    sortByUpdated(nodes)
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/
+/*/ sortByUpdated(nodes)
     {
       if (nodes) {
         return nodes.sort( (a,b) => {
@@ -371,13 +372,12 @@ render() {
       this.handleDataUpdate(D3DATA);
     }
 
-  componentWillUnmount() {
-    this.AppStateChangeOff('D3DATA', this.handleDataUpdate);
-    this.AppStateChangeOff('TEMPLATE', this.OnTemplateUpdate);
-  }
+    componentWillUnmount() {
+      this.AppStateChangeOff('D3DATA', this.handleDataUpdate);
+      this.AppStateChangeOff('TEMPLATE', this.OnTemplateUpdate);
+    }
 
-displayUpdated(nodeEdge)
-  {
+    displayUpdated(nodeEdge) {
       var d = new Date(nodeEdge.meta.revision > 0 ? nodeEdge.meta.updated : nodeEdge.meta.created);
 
       var year = "" + d.getFullYear();

--- a/build/app/view/netcreate/components/Search.jsx
+++ b/build/app/view/netcreate/components/Search.jsx
@@ -76,7 +76,7 @@ class Search extends UNISYS.Component {
               disabledValue={this.state.searchString}
               inactiveMode={'disabled'}
             />
-            <Label style={{ float: 'left' }} className="small text-muted">Type to search or add a node:</Label>
+            <Label className="small text-muted">Type to search or add a node:</Label>
           </Col>
         </FormGroup>
       )

--- a/build/app/view/netcreate/components/Vocabulary.jsx
+++ b/build/app/view/netcreate/components/Vocabulary.jsx
@@ -23,102 +23,71 @@ const UNISYS   = require('unisys/client');
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// export a class object for consumption by brunch/require
 class Vocabulary extends UNISYS.Component {
-    constructor (props) {
-      super(props);
-      this.state = {isExpanded: true};
+  constructor (props) {
+    super(props);
+    this.state = {isExpanded: true};
+  } // constructor
 
-      this.onToggleExpanded         = this.onToggleExpanded.bind(this);
+  render () {
+    let { tableHeight } = this.props;
 
-          } // constructor
+    return (
+      <div
+        style={{
+          backgroundColor: 'rgba(240,240,240,0.95)',
+          padding: '10px 20px'
+        }}>
 
+        <dl>
+          <dt>Network</dt>
+        <dd>This is a collection of nodes and the edges between them. </dd>
 
+        <dt>Graph</dt>
+        <dd>a graphic representation of a network and its components. <em><strong>Similar terms include:</strong> sociogram, visualization</em></dd>
 
-/// UI EVENT HANDLERS /////////////////////////////////////////////////////////
-/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/*/
-/*/ onToggleExpanded (event) {
-      this.setState({
-        isExpanded: !this.state.isExpanded
-      })
-    }
+        <dt>Node</dt>
+        <dd>The thing or <em>entity</em> (shown as circles) that is connected through relationships. This could be individual people, groups of people, institutions (like churches, organizations, schools). One way of thinking about this is that nodes are nouns and edges are verbs - nodes are things that are connected through edges. <em><strong>Similar terms include:</strong> actor, vertex</em></dd>
+          <ul>
+          <dl>
+            <dt>Ego</dt>
+            <dd>This refers to the node you are focused on at the moment and the connections that they have. </dd>
+        </dl>
+        </ul>
 
+        <dt>Edge</dt>
+        <dd>The relationships between nodes you are considering (shown as lines). Relationships can take on many forms: nodes could be connected through somewhat intangible relationships, such as friendship or not liking one another. Edges can be based on interactions, such as talking to one another or being in conflict. They could also be defined by sharing resources, such as money or information. <em><strong>Similar terms include:</strong> line, tie, arc</em></dd>
 
+          <ul><dl>
+          <dt>Edge weight</dt>
+          <dd>Edges can have a value attached to them. So, for instance, an node could sent $10,000 to another actor. Or, they could share three interactions of the same type with one another. This value is referred to as a weight. <em><strong>Similar terms include:</strong> value</em></dd>
 
-/// REACT LIFECYCLE METHODS ///////////////////////////////////////////////////
-/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/*/ This is not yet implemented as of React 16.2.  It's implemented in 16.3.
-    getDerivedStateFromProps (props, state) {
-      console.error('getDerivedStateFromProps!!!');
-    }
-/*/
-/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/*/
-/*/ render () {
-        let { tableHeight } = this.props;
+          <dt>Directed or undirected edges</dt>
+          <dd>Edges can either be directed or undirected. If a relationship is directed, it is being sent from (originating from) one node to another node. Node A may say they are friends with Node B, but Node B does not say Node A does this. Or Node A gives Node B something, such as resources, information, or an illness. However, in some cases, edges are defined as undirected. Two people who share a meal together or are married are both engaged share an undirected edge. <em>Note: in some academic literatures, the term "edge" is reserved for an undirected relationship, while the term "arc" is used to refer to directed ties.</em></dd>
+          </dl></ul>
 
-      return (
-        <div className="help"
-             style={{ overflow: 'auto', maxWidth: '50%', position: 'fixed', right: '10px',
-                      maxHeight: tableHeight
-             }}>
-          <Button size="sm" outline hidden
-            style={{float:'right'}}
-            onClick={this.onToggleExpanded}
-          >{this.state.isExpanded ? "Hide Vocabulary" : "Vocabulary"}</Button>
-          <div hidden={!this.state.isExpanded}
-            style={{backgroundColor:'rgba(240,240,240,0.95)',padding:'10px 20px'}}>
+        <dt>Attributes</dt>
+        <dd>Characteristics of the nodes or edges. A node could be designated by gender, for instance or the amount of wealth they possess. They could also be characteristics you find from the network itself - such as how many ties an node has (degree centrality). </dd>
 
-            <dl>
-             <dt>Network</dt>
-            <dd>This is a collection of nodes and the edges between them. </dd>
+        <dt>Centrality</dt>
+        <dd>This is a way of ranking the importance of individuals within a network. There are many different ways to measure importance, such as degree centrality, betweenness centrality, and eigenvector centrality.  </dd>
+        <ul> <dl>
 
-            <dt>Graph</dt>
-            <dd>a graphic representation of a network and its components. <em><strong>Similar terms include:</strong> sociogram, visualization</em></dd>
+        <dt>Degree Centrality</dt>
+        <dd>Degree centrality is a measure of how many connections a node has. An node with many ties that are being sent to them has a high in-degree centrality. In a friendship network, this can be easily recognized as popularity. Nodes sending many outgoing ties (high out-degree centrality) may be thought of as expansive in their relationship.</dd>
 
-           <dt>Node</dt>
-            <dd>The thing or <em>entity</em> (shown as circles) that is connected through relationships. This could be individual people, groups of people, institutions (like churches, organizations, schools). One way of thinking about this is that nodes are nouns and edges are verbs - nodes are things that are connected through edges. <em><strong>Similar terms include:</strong> actor, vertex</em></dd>
-             <ul>
-             <dl>
-                <dt>Ego</dt>
-                <dd>This refers to the node you are focused on at the moment and the connections that they have. </dd>
-            </dl>
-            </ul>
+        <dt>Betweenness Centrality</dt>
+        <dd>Nodes with high betweenness centrality serve as connectors between other individuals who wouldn't otherwise be directly connected. They may not be connected to a large number of people (that would be high degree centrality), but they are unique in their connections. If an actor with high betweenness centrality was removed from a network, the network would be more fragmented and less connected. Often researchers are interested in finding actors with high betweenness centrality because they can control whatever flows in the networks. For instance, military analysts often look for nodes with high betweenness in a terrorist network.</dd>
 
-            <dt>Edge</dt>
-            <dd>The relationships between nodes you are considering (shown as lines). Relationships can take on many forms: nodes could be connected through somewhat intangible relationships, such as friendship or not liking one another. Edges can be based on interactions, such as talking to one another or being in conflict. They could also be defined by sharing resources, such as money or information. <em><strong>Similar terms include:</strong> line, tie, arc</em></dd>
+        <dt>Eigenvector Centrality</dt>
+        <dd>Eigenvector centrality ranks actors based on their connection to other highly central nodes. So, a nodes importance as measured by eigenvector centrality are dependent on the other nodes with whom they share connections. Google's PageRank algorithm was a famous application of a version of this type of centrality, and allowed them to return highly relevant results in search for users.</dd>
+        </dl></ul>
 
-              <ul><dl>
-              <dt>Edge weight</dt>
-              <dd>Edges can have a value attached to them. So, for instance, an node could sent $10,000 to another actor. Or, they could share three interactions of the same type with one another. This value is referred to as a weight. <em><strong>Similar terms include:</strong> value</em></dd>
-
-              <dt>Directed or undirected edges</dt>
-              <dd>Edges can either be directed or undirected. If a relationship is directed, it is being sent from (originating from) one node to another node. Node A may say they are friends with Node B, but Node B does not say Node A does this. Or Node A gives Node B something, such as resources, information, or an illness. However, in some cases, edges are defined as undirected. Two people who share a meal together or are married are both engaged share an undirected edge. <em>Note: in some academic literatures, the term "edge" is reserved for an undirected relationship, while the term "arc" is used to refer to directed ties.</em></dd>
-              </dl></ul>
-
-            <dt>Attributes</dt>
-            <dd>Characteristics of the nodes or edges. A node could be designated by gender, for instance or the amount of wealth they possess. They could also be characteristics you find from the network itself - such as how many ties an node has (degree centrality). </dd>
-
-            <dt>Centrality</dt>
-            <dd>This is a way of ranking the importance of individuals within a network. There are many different ways to measure importance, such as degree centrality, betweenness centrality, and eigenvector centrality.  </dd>
-            <ul> <dl>
-
-            <dt>Degree Centrality</dt>
-            <dd>Degree centrality is a measure of how many connections a node has. An node with many ties that are being sent to them has a high in-degree centrality. In a friendship network, this can be easily recognized as popularity. Nodes sending many outgoing ties (high out-degree centrality) may be thought of as expansive in their relationship.</dd>
-
-            <dt>Betweenness Centrality</dt>
-            <dd>Nodes with high betweenness centrality serve as connectors between other individuals who wouldn't otherwise be directly connected. They may not be connected to a large number of people (that would be high degree centrality), but they are unique in their connections. If an actor with high betweenness centrality was removed from a network, the network would be more fragmented and less connected. Often researchers are interested in finding actors with high betweenness centrality because they can control whatever flows in the networks. For instance, military analysts often look for nodes with high betweenness in a terrorist network.</dd>
-
-            <dt>Eigenvector Centrality</dt>
-            <dd>Eigenvector centrality ranks actors based on their connection to other highly central nodes. So, a nodes importance as measured by eigenvector centrality are dependent on the other nodes with whom they share connections. Google's PageRank algorithm was a famous application of a version of this type of centrality, and allowed them to return highly relevant results in search for users.</dd>
-            </dl></ul>
-
-            <dt>Communities</dt>
-            <dd>A community in a network is a way of thinking about grouping, often by finding densely connected sets of nodes. A community within a network that is tightly connected to one another but not to an outside group might be seen as a faction, such as rival political groups. In this case, nodes with high betweenness centrality in a network with multiple factions might be some of the only points of contact between rival groups - a potentially powerful but also difficult position to be in.</dd>
-            </dl>
-          </div>
-        </div>
-      );
-    }
+        <dt>Communities</dt>
+        <dd>A community in a network is a way of thinking about grouping, often by finding densely connected sets of nodes. A community within a network that is tightly connected to one another but not to an outside group might be seen as a faction, such as rival political groups. In this case, nodes with high betweenness centrality in a network with multiple factions might be some of the only points of contact between rival groups - a potentially powerful but also difficult position to be in.</dd>
+        </dl>
+      </div>
+    );
+  }
 
 } // class Vocabulary
 

--- a/build/app/view/netcreate/components/Vocabulary.jsx
+++ b/build/app/view/netcreate/components/Vocabulary.jsx
@@ -58,8 +58,8 @@ class Vocabulary extends UNISYS.Component {
 
       return (
         <div className="help"
-             style={{ overflow:'auto',
-                      position:'relative', display: 'block', maxHeight: tableHeight
+             style={{ overflow: 'auto', maxWidth: '50%', position: 'fixed', right: '10px',
+                      maxHeight: tableHeight
              }}>
           <Button size="sm" outline hidden
             style={{float:'right'}}

--- a/build/app/view/netcreate/components/Vocabulary.jsx
+++ b/build/app/view/netcreate/components/Vocabulary.jsx
@@ -58,15 +58,15 @@ class Vocabulary extends UNISYS.Component {
 
       return (
         <div className="help"
-             style={{overflow:'auto',
-                     position:'relative',display: 'block', right:'10px',maxHeight: tableHeight
+             style={{ overflow:'auto',
+                      position:'relative', display: 'block', maxHeight: tableHeight
              }}>
           <Button size="sm" outline hidden
             style={{float:'right'}}
             onClick={this.onToggleExpanded}
           >{this.state.isExpanded ? "Hide Vocabulary" : "Vocabulary"}</Button>
           <div hidden={!this.state.isExpanded}
-            style={{backgroundColor:'rgba(240,240,240,0.95)',padding:'10px'}}>
+            style={{backgroundColor:'rgba(240,240,240,0.95)',padding:'10px 20px'}}>
 
             <dl>
              <dt>Network</dt>

--- a/build/app/view/netcreate/components/d3-simplenetgraph.js
+++ b/build/app/view/netcreate/components/d3-simplenetgraph.js
@@ -331,7 +331,7 @@ class D3NetGraph {
           return COLORMAP[d.attributes["Node_Type"]];
         })
         .style("opacity", d => {
-          return d.isFilteredOut ? d.filteredTransparency : 1.0
+          return d.filteredTransparency
         });
 
       // enter node: also append 'text' element
@@ -343,7 +343,7 @@ class D3NetGraph {
           .attr("dy", "0.35em") // ".15em")
           .text((d) => { return d.label })
           .style("opacity", d => {
-            return d.isFilteredOut ? d.filteredTransparency : 1.0
+            return d.filteredTransparency
           });
 
       // enter node: also append a 'title' tag
@@ -422,7 +422,7 @@ class D3NetGraph {
           .duration(500)
           .style("opacity", d => {
             // console.log(d);
-            return d.isFilteredOut ? d.filteredTransparency : 1.0
+            return d.filteredTransparency
           });
 
       // UPDATE text in each node for all nodes
@@ -443,7 +443,7 @@ class D3NetGraph {
           .transition()
           .duration(500)
           .style("opacity", d => {
-            return d.isFilteredOut ? d.filteredTransparency : 1.0
+            return d.filteredTransparency
           });
 
       nodeElements.merge(nodeElements)
@@ -471,7 +471,7 @@ class D3NetGraph {
         //   this.edgeClickFn( d )
         // })
         .style("opacity", d => {
-          return d.isFilteredOut ? d.filteredTransparency : 1.0
+          return d.filteredTransparency
         });
 
       // .merge() updates the visuals whenever the data is updated.
@@ -482,7 +482,7 @@ class D3NetGraph {
         .transition()
         .duration(500)
         .style("opacity", d => {
-          return d.isFilteredOut ? d.filteredTransparency : 1.0
+          return d.filteredTransparency
         });
 
       linkElements.exit().remove()

--- a/build/app/view/netcreate/components/d3-simplenetgraph.js
+++ b/build/app/view/netcreate/components/d3-simplenetgraph.js
@@ -166,7 +166,7 @@ class D3NetGraph {
       this._Dragended         = this._Dragended.bind(this);
 
       // V1.4 CHANGE
-      // Ignore D3DATA Updates!!!  Only listen to FILTERED_D3DATA Updates
+      // Ignore D3DATA Updates!!!  Only listen to FILTEREDD3DATA Updates
       //
       // watch for updates to the D3DATA data object
       // UDATA.OnAppStateChange('D3DATA',(data)=>{
@@ -176,9 +176,9 @@ class D3NetGraph {
       // });
 
       // Special handler for the remove filter
-      UDATA.HandleMessage('FILTERED_D3DATA',(data)=>{
+      UDATA.OnAppStateChange('FILTEREDD3DATA',(data)=>{
         // expect { nodes, edges } for this namespace
-        if (DBG) console.log(PR,'got state FILTERED_D3DATA',data);
+        if (DBG) console.log(PR,'got state FILTEREDD3DATA',data);
         this._SetData(data);
       });
 

--- a/build/app/view/netcreate/components/d3-simplenetgraph.js
+++ b/build/app/view/netcreate/components/d3-simplenetgraph.js
@@ -403,20 +403,20 @@ class D3NetGraph {
             if (d.selected || d.strokeColor) return '5px';
             return undefined // don't set stroke width
           })
-// this "r" is necessary to resize after a link is added
           .attr("fill", (d) => {
             // REVIEW: Using label match.  Should we use id instead?
             return COLORMAP[d.attributes["Node_Type"]];
           })
           .attr("r", (d) => {
-              let radius = this.data.edges.reduce((acc,ed)=>{
-                return (ed.source.id===d.id || ed.target.id===d.id) ? acc+1 : acc
-              },1);
+            // this "r" is necessary to resize after a link is added
+            let radius = this.data.edges.reduce((acc,ed)=>{
+              return (ed.source.id===d.id || ed.target.id===d.id) ? acc+1 : acc
+            },1);
 
-              d.weight = radius
-              d.size = radius // save the calculated size
-              d.degrees = radius - 1
-              return this.defaultSize + (this.defaultSize * d.weight / 2)
+            d.weight = radius
+            d.size = radius // save the calculated size
+            d.degrees = radius - 1
+            return this.defaultSize + (this.defaultSize * d.weight / 2)
           })
           .transition()
           .duration(500)

--- a/build/app/view/netcreate/components/d3-simplenetgraph.js
+++ b/build/app/view/netcreate/components/d3-simplenetgraph.js
@@ -2,6 +2,8 @@
 
     D3 Simple NetGraph
 
+    This uses D3 Version 4.0.
+
     This is designed to work with the NetGraph React component.
 
     NetGraph calls SetData whenever it receives an updated data object.
@@ -192,6 +194,7 @@ class D3NetGraph {
 
       UDATA.HandleMessage('ZOOM_RESET', (data) => {
         if (DBG) console.log(PR, 'ZOOM_RESET got state D3DATA', data);
+        // NOTE: The transition/duration call means _HandleZoom will be called multiple times
         this.d3svg.transition()
           .duration(200)
           .call(this.zoom.scaleTo, 1);
@@ -207,6 +210,13 @@ class D3NetGraph {
         this._Transition(0.8);
       });
 
+      // Pan to 0,0 and zoom scale to 1
+      // (Currently not used)
+      UDATA.HandleMessage('ZOOM_PAN_RESET', (data) => {
+        if (DBG) console.log(PR, 'ZOOM_PAN_RESET got state D3DATA', data);
+        const transform = d3.zoomIdentity.translate(0, 0).scale(1);
+        this.d3svg.call(this.zoom.transform, transform);
+      });
 
       UDATA.HandleMessage('GROUP_PROPS', (data) => {
         console.log('GROUP_PROPS got ... ');

--- a/build/app/view/netcreate/components/d3-simplenetgraph.js
+++ b/build/app/view/netcreate/components/d3-simplenetgraph.js
@@ -425,6 +425,8 @@ class D3NetGraph {
 
             d.weight = radius
             d.size = radius // save the calculated size
+            // radius is calculated by counting the number of edges attached
+            // (+ 1 for a minimum radius), so we hack degrees by using radius-1
             d.degrees = radius - 1
             return this.defaultSize + (this.defaultSize * d.weight / 2)
           })

--- a/build/app/view/netcreate/components/d3-simplenetgraph.js
+++ b/build/app/view/netcreate/components/d3-simplenetgraph.js
@@ -165,10 +165,20 @@ class D3NetGraph {
       this._Dragged           = this._Dragged.bind(this);
       this._Dragended         = this._Dragended.bind(this);
 
+      // V1.4 CHANGE
+      // Ignore D3DATA Updates!!!  Only listen to FILTERED_D3DATA Updates
+      //
       // watch for updates to the D3DATA data object
-      UDATA.OnAppStateChange('D3DATA',(data)=>{
+      // UDATA.OnAppStateChange('D3DATA',(data)=>{
+      //   // expect { nodes, edges } for this namespace
+      //   if (DBG) console.error(PR,'got state D3DATA',data);
+      //   this._SetData(data);
+      // });
+
+      // Special handler for the remove filter
+      UDATA.HandleMessage('FILTERED_D3DATA',(data)=>{
         // expect { nodes, edges } for this namespace
-        if (DBG) console.log(PR,'got state D3DATA',data);
+        if (DBG) console.log(PR,'got state FILTERED_D3DATA',data);
         this._SetData(data);
       });
 

--- a/build/app/view/netcreate/components/filter/FilterEnums.js
+++ b/build/app/view/netcreate/components/filter/FilterEnums.js
@@ -1,5 +1,10 @@
 const FILTER = {};
 
+// Determines whether filter action is to highlight/fade or remove (filter) nodes and edges
+FILTER.ACTION = {};
+FILTER.ACTION.HIGHLIGHT = 'highlight';
+FILTER.ACTION.FILTER = 'filter';
+
 // Types of filters definable in template files.
 FILTER.TYPES = {};
 FILTER.TYPES.STRING = 'string';

--- a/build/app/view/netcreate/components/filter/FilterGroup.jsx
+++ b/build/app/view/netcreate/components/filter/FilterGroup.jsx
@@ -8,7 +8,7 @@ const ReactStrap = require('reactstrap');
 const { Input, Label } = ReactStrap;
 
 export default function FilterGroup({
-  group, label, filters, transparency
+  group, label, filters, filterAction, transparency
 }) {
   return (
     <div className="filter-group" style={{margin:'5px 5px 5px 0',padding:'10px',backgroundColor:'rgba(0,0,0,0)'}}>
@@ -17,13 +17,13 @@ export default function FilterGroup({
         switch (filter.type) {
           case FILTER.TYPES.STRING:
           case FILTER.TYPES.NODE:
-            return <StringFilter key={filter.id} group={group} filter={filter} />
+            return <StringFilter key={filter.id} group={group} filter={filter} filterAction={filterAction}/>
             break;
           case FILTER.TYPES.NUMBER:
-            return <NumberFilter key={filter.id} group={group} filter={filter} />
+            return <NumberFilter key={filter.id} group={group} filter={filter} filterAction={filterAction}/>
             break;
           case FILTER.TYPES.SELECT:
-            return <SelectFilter key={filter.id} group={group} filter={filter} />
+            return <SelectFilter key={filter.id} group={group} filter={filter} filterAction={filterAction}/>
             break;
           default:
             console.error(`FilterGroup: Filter Type not found ${filter.type} for filter`, filter);

--- a/build/app/view/netcreate/components/filter/FilterGroup.jsx
+++ b/build/app/view/netcreate/components/filter/FilterGroup.jsx
@@ -31,8 +31,8 @@ export default function FilterGroup({
         }
         return '';
       })}
-      <hr/>
       <FilterGroupProperties group={group} transparency={transparency} />
+      <hr/>
     </div>
   );
 }

--- a/build/app/view/netcreate/components/filter/FilterGroupProperties.jsx
+++ b/build/app/view/netcreate/components/filter/FilterGroupProperties.jsx
@@ -62,22 +62,21 @@ class FilterGroupProperties extends React.Component {
     e.stopPropagation();
   }
 
-  render (){
+  render () {
     const { group, transparency } = this.props;
-
-    return(
-    <div>
-      <div className="small text-muted" style={{fontWeight:'bold',textTransform:'uppercase',marginBottom:'0.4em'}}>Settings for {group}</div>
-           <Form inline className="filter-item" key={group} onSubmit={this.OnSubmit}>
-            <FormGroup><Label size="sm" className="small text-muted"
-              style={{ fontSize: '0.75em', lineHeight: '1em', width: `5em`, marginLeft: '0em'}}>
-              Transparency&nbsp;</Label>
-              <Input type="text" value={transparency}
-              style={{maxWidth:'9em', height:'1.5em', marginLeft: '1em'}}
-              onChange={this.OnChangeValue} bsSize="sm" />
-              </FormGroup>
-            </Form>
-        </div>
+    return (
+      <div>
+        <br/>
+        <Form inline className="filter-item" key={group} onSubmit={this.OnSubmit}>
+        <FormGroup><Label size="sm" className="small text-muted"
+          style={{ fontSize: '0.75em', lineHeight: '1em', width: `5em`, marginLeft: '0em'}}>
+          Transparency&nbsp;</Label>
+          <Input type="text" value={transparency}
+          style={{maxWidth:'9em', height:'1.5em', marginLeft: '1em'}}
+          onChange={this.OnChangeValue} bsSize="sm" />
+          </FormGroup>
+        </Form>
+      </div>
 );
   }
 

--- a/build/app/view/netcreate/components/filter/FilterGroupProperties.jsx
+++ b/build/app/view/netcreate/components/filter/FilterGroupProperties.jsx
@@ -20,6 +20,7 @@ class FilterGroupProperties extends React.Component {
     super();
     this.OnChangeValue = this.OnChangeValue.bind(this);
     this.TriggerChangeHandler = this.TriggerChangeHandler.bind(this);
+    this.OnSubmit = this.OnSubmit.bind(this);
 
     this.state = {
       group: group,
@@ -55,13 +56,19 @@ class FilterGroupProperties extends React.Component {
 
   }
 
+  OnSubmit(e) {
+    // Prevent "ENTER" from triggering form submission!
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
   render (){
     const { group, transparency } = this.props;
 
     return(
     <div>
       <div className="small text-muted" style={{fontWeight:'bold',textTransform:'uppercase',marginBottom:'0.4em'}}>Settings for {group}</div>
-           <Form inline className="filter-item" key={group}>
+           <Form inline className="filter-item" key={group} onSubmit={this.OnSubmit}>
             <FormGroup><Label size="sm" className="small text-muted"
               style={{ fontSize: '0.75em', lineHeight: '1em', width: `5em`, marginLeft: '0em'}}>
               Transparency&nbsp;</Label>

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -70,14 +70,15 @@ class FiltersPanel extends UNISYS.Component {
 
   render() {
     const { filterAction } = this.state;
-    const { tableHeight } = this.props;
     const defs = [this.state.nodes, this.state.edges];
     return (
       <div className="filterPanel"
         style={{
-          overflow: 'auto', position: 'relative',
+          overflow: 'auto',
+          marginTop: '6px', padding: '5px',
           display: 'flex', flexDirection: 'column',
-          maxHeight: tableHeight
+          backgroundColor: '#EEE',
+          zIndex: '2000'
         }}>
         <ButtonGroup>
           <Button
@@ -85,12 +86,14 @@ class FiltersPanel extends UNISYS.Component {
             active={filterAction === FILTER.ACTION.HIGHLIGHT}
             outline={filterAction === FILTER.ACTION.HIGHLIGHT}
             disabled={filterAction === FILTER.ACTION.HIGHLIGHT}
+            style={{ color: filterAction === FILTER.ACTION.HIGHLIGHT ? '#333' : '#fff' }}
           >Highlight</Button>
           <Button
             onClick={() => this.SelectFilterAction(FILTER.ACTION.FILTER)}
             active={filterAction === FILTER.ACTION.FILTER}
             outline={filterAction === FILTER.ACTION.FILTER}
             disabled={filterAction === FILTER.ACTION.FILTER}
+            style={{ color: filterAction === FILTER.ACTION.FILTER ? '#333' : '#fff' }}
           >Filter</Button>
         </ButtonGroup>
         <Label className="small text-muted" style={{ padding: '0.5em 0 0 0.5em', marginBottom: '0' }}>
@@ -99,7 +102,8 @@ class FiltersPanel extends UNISYS.Component {
             : 'Filter shows only nodes/edges that match criteria.  (Removes others)'
           }
         </Label>
-        <div style={{ display: 'flex', flexGrow: `1`, justifyContent: 'space-evenly' }}>
+        <hr/>
+        <div style={{ display: 'flex', flexDirection: 'column', flexGrow: `1`, justifyContent: 'space-evenly' }}>
           {defs.map(def => <FilterGroup
             key={def.label}
             group={def.group}
@@ -111,7 +115,7 @@ class FiltersPanel extends UNISYS.Component {
           />)}
         </div>
         <div style={{ display: 'flex', justifyContent: 'space-evenly', padding: '10px' }}>
-          <Button size="sm" onClick={this.OnClearBtnClick}>Clear Filters</Button>
+          <Button size="sm" onClick={this.OnClearBtnClick} >Clear Filters</Button>
         </div>
       </div>
     )

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -95,7 +95,7 @@ class FiltersPanel extends UNISYS.Component {
         <Label className="small text-muted" style={{ padding: '0.5em 0 0 0.5em', marginBottom: '0' }}>
           {filterAction === FILTER.ACTION.HIGHLIGHT
             ? 'Highlight nodes/edges that match criteria. (Fade others)'
-            : 'Filter (remove) nodes/edges that match criteria.'
+            : 'Filter shows only nodes/edges that match criteria.  (Removes others)'
           }
         </Label>
         <div style={{ display: 'flex', flexGrow: `1`, justifyContent: 'space-evenly' }}>

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -56,7 +56,13 @@ class FiltersPanel extends UNISYS.Component {
   }
 
   UpdateFilterDefs(data) {
-    this.setState(data);
+    this.setState(state => {
+      return {
+        nodes: data.nodes,
+        edges: data.edges,
+        filterAction: data.filterAction || state.filterAction
+      }
+    });
   }
 
   OnClearBtnClick() {
@@ -86,14 +92,20 @@ class FiltersPanel extends UNISYS.Component {
             active={filterAction === FILTER.ACTION.HIGHLIGHT}
             outline={filterAction === FILTER.ACTION.HIGHLIGHT}
             disabled={filterAction === FILTER.ACTION.HIGHLIGHT}
-            style={{ color: filterAction === FILTER.ACTION.HIGHLIGHT ? '#333' : '#fff' }}
+            style={{
+              color: filterAction === FILTER.ACTION.HIGHLIGHT ? '#333' : '#fff',
+              backgroundColor: filterAction === FILTER.ACTION.HIGHLIGHT ? 'transparent' : '#6c757d88'
+            }}
           >Highlight</Button>
           <Button
             onClick={() => this.SelectFilterAction(FILTER.ACTION.FILTER)}
             active={filterAction === FILTER.ACTION.FILTER}
             outline={filterAction === FILTER.ACTION.FILTER}
             disabled={filterAction === FILTER.ACTION.FILTER}
-            style={{ color: filterAction === FILTER.ACTION.FILTER ? '#333' : '#fff' }}
+            style={{
+              color: filterAction === FILTER.ACTION.FILTER ? '#333' : '#fff',
+              backgroundColor: filterAction === FILTER.ACTION.FILTER ? 'transparent' : '#6c757d88'
+            }}
           >Filter</Button>
         </ButtonGroup>
         <Label className="small text-muted" style={{ padding: '0.5em 0 0 0.5em', marginBottom: '0' }}>

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -60,7 +60,7 @@ class FiltersPanel extends UNISYS.Component {
   }
 
   render() {
-    const { tableHeight } = this.props;
+    const { tableHeight, filterAction } = this.props;
     const defs = [this.state.nodes, this.state.edges];
     return (
       <div className="filterPanel"
@@ -75,6 +75,7 @@ class FiltersPanel extends UNISYS.Component {
             group={def.group}
             label={def.label}
             filters={def.filters}
+            filterAction={filterAction}
             transparency={def.transparency}
             onFiltersChange={this.OnFilterChange}
           />)}

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -41,9 +41,12 @@ class FiltersPanel extends UNISYS.Component {
     // The intial `OnAppStateChange("FDATA")` event when the template is
     // first loaded is called well before FiltersPanel is
     // even constructed.  So we need to explicitly load it here.
-    let FDATA = UDATA.AppState("FDATA");
-    this.state = FDATA;
-
+    const FDATA = UDATA.AppState("FDATA");
+    this.state = {
+      nodes: FDATA.nodes,
+      edges: FDATA.edges,
+      filterAction: FILTER.ACTION.HIGHLIGHT
+    };
     UDATA.OnAppStateChange("FDATA", this.UpdateFilterDefs);
   } // constructor
 

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -69,6 +69,12 @@ class FiltersPanel extends UNISYS.Component {
           display: 'flex', flexDirection: 'column',
           maxHeight: tableHeight
         }}>
+        <Label className="small text-muted" style={{ padding: '0.5em 0 0 0.5em', marginBottom: '0' }}>
+          {filterAction === FILTER.ACTION.HIGHLIGHT
+            ? 'Highlight nodes/edges that match criteria. (Fade others)'
+            : 'Remove nodes/edges that match criteria.'
+          }
+        </Label>
         <div style={{ display: 'flex', flexGrow: `1`, justifyContent: 'space-evenly' }}>
           {defs.map(def => <FilterGroup
             key={def.label}

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -52,6 +52,7 @@ class FiltersPanel extends UNISYS.Component {
 
   componentWillUnmount() {
     // console.error('TBD: gracefully unsubscribe!')
+    UDATA.AppStateChangeOff("FDATA", this.UpdateFilterDefs);
   }
 
   UpdateFilterDefs(data) {

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -46,6 +46,9 @@ class FiltersPanel extends UNISYS.Component {
     UDATA.OnAppStateChange("FDATA", this.UpdateFilterDefs);
   } // constructor
 
+  componentWillUnmount() {
+    // console.error('TBD: gracefully unsubscribe!')
+  }
 
   UpdateFilterDefs(data) {
     this.setState(data);
@@ -55,8 +58,6 @@ class FiltersPanel extends UNISYS.Component {
     UDATA.LocalCall('FILTER_CLEAR');
   }
 
-  componentWillUnmount() {
-    // console.error('TBD: gracefully unsubscribe!')
   }
 
   render() {

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -20,7 +20,7 @@ import React from 'react';
 import StringFilter from './StringFilter';
 const ReactStrap = require('reactstrap');
 
-const { Button, Input, Label } = ReactStrap;
+const { Button, ButtonGroup, Input, Label } = ReactStrap;
 
 const UNISYS = require('unisys/client');
 var UDATA  = null;
@@ -32,8 +32,9 @@ class FiltersPanel extends UNISYS.Component {
 
     this.UpdateFilterDefs = this.UpdateFilterDefs.bind(this);
     this.OnClearBtnClick = this.OnClearBtnClick.bind(this);
+    this.SelectFilterAction = this.SelectFilterAction.bind(this);
 
-     /// Initialize UNISYS DATA LINK for REACT
+    /// Initialize UNISYS DATA LINK for REACT
     UDATA = UNISYS.NewDataLink(this);
 
     // Load Templates
@@ -58,10 +59,14 @@ class FiltersPanel extends UNISYS.Component {
     UDATA.LocalCall('FILTER_CLEAR');
   }
 
+  SelectFilterAction(filterAction) {
+    this.setState({ filterAction });
+    UDATA.LocalCall('FILTERS_UPDATE', { filterAction });
   }
 
   render() {
-    const { tableHeight, filterAction } = this.props;
+    const { filterAction } = this.state;
+    const { tableHeight } = this.props;
     const defs = [this.state.nodes, this.state.edges];
     return (
       <div className="filterPanel"
@@ -70,10 +75,24 @@ class FiltersPanel extends UNISYS.Component {
           display: 'flex', flexDirection: 'column',
           maxHeight: tableHeight
         }}>
+        <ButtonGroup>
+          <Button
+            onClick={() => this.SelectFilterAction(FILTER.ACTION.HIGHLIGHT)}
+            active={filterAction === FILTER.ACTION.HIGHLIGHT}
+            outline={filterAction === FILTER.ACTION.HIGHLIGHT}
+            disabled={filterAction === FILTER.ACTION.HIGHLIGHT}
+          >Highlight</Button>
+          <Button
+            onClick={() => this.SelectFilterAction(FILTER.ACTION.FILTER)}
+            active={filterAction === FILTER.ACTION.FILTER}
+            outline={filterAction === FILTER.ACTION.FILTER}
+            disabled={filterAction === FILTER.ACTION.FILTER}
+          >Filter</Button>
+        </ButtonGroup>
         <Label className="small text-muted" style={{ padding: '0.5em 0 0 0.5em', marginBottom: '0' }}>
           {filterAction === FILTER.ACTION.HIGHLIGHT
             ? 'Highlight nodes/edges that match criteria. (Fade others)'
-            : 'Remove nodes/edges that match criteria.'
+            : 'Filter (remove) nodes/edges that match criteria.'
           }
         </Label>
         <div style={{ display: 'flex', flexGrow: `1`, justifyContent: 'space-evenly' }}>

--- a/build/app/view/netcreate/components/filter/NumberFilter.js
+++ b/build/app/view/netcreate/components/filter/NumberFilter.js
@@ -129,7 +129,8 @@ class NumberFilter extends React.Component {
             )}
           </Input>
           <Input type="text" value={value} placeholder="..."
-            onChange={this.OnChangeValue} bsSize="sm" />
+            onChange={this.OnChangeValue} bsSize="sm"
+            disabled={operator === FILTER.OPERATORS.NO_OP.key}/>
         </FormGroup>
       </Form>
     );

--- a/build/app/view/netcreate/components/filter/NumberFilter.js
+++ b/build/app/view/netcreate/components/filter/NumberFilter.js
@@ -133,12 +133,14 @@ class NumberFilter extends React.Component {
             {keylabel}&nbsp;
           </Label>
           <Input type="select" value={operator}
+            style={{maxWidth:'12em', height:'1.5em', padding: '0'}}
             onChange={this.OnChangeOperator} bsSize="sm">
             {OPERATORS.map(op =>
               <option value={op.key} key={`${id}${op.key}`} size="sm">{op.label}</option>
             )}
           </Input>
           <Input type="text" value={value} placeholder="..."
+            style={{maxWidth:'12em', height:'1.5em', padding: '0'}}
             onChange={this.OnChangeValue} bsSize="sm"
             disabled={operator === FILTER.OPERATORS.NO_OP.key}/>
         </FormGroup>

--- a/build/app/view/netcreate/components/filter/NumberFilter.js
+++ b/build/app/view/netcreate/components/filter/NumberFilter.js
@@ -95,6 +95,7 @@ class NumberFilter extends React.Component {
   }
 
   TriggerChangeHandler() {
+    const { filterAction } = this.props;
     const { id, type, key, keylabel } = this.props.filter;
     const filter = {
       id,
@@ -106,11 +107,13 @@ class NumberFilter extends React.Component {
     };
     UDATA.LocalCall('FILTER_DEFINE', {
       group: this.props.group,
-      filter
+      filter,
+      filterAction
     }); // set a SINGLE filter
   }
 
   render() {
+    const { filterAction } = this.props;
     const { id, key, keylabel, operator, value } = this.props.filter;
     return (
       <Form inline className="filter-item" key={id}>

--- a/build/app/view/netcreate/components/filter/NumberFilter.js
+++ b/build/app/view/netcreate/components/filter/NumberFilter.js
@@ -106,7 +106,7 @@ class NumberFilter extends React.Component {
       operator: this.state.operator,
       value: this.state.value
     };
-    UDATA.LocalCall('FILTER_DEFINE', {
+    if (UDATA) UDATA.LocalCall('FILTER_DEFINE', {
       group: this.props.group,
       filter,
       filterAction

--- a/build/app/view/netcreate/components/filter/NumberFilter.js
+++ b/build/app/view/netcreate/components/filter/NumberFilter.js
@@ -72,6 +72,7 @@ class NumberFilter extends React.Component {
     this.OnChangeOperator = this.OnChangeOperator.bind(this);
     this.OnChangeValue = this.OnChangeValue.bind(this);
     this.TriggerChangeHandler = this.TriggerChangeHandler.bind(this);
+    this.OnSubmit = this.OnSubmit.bind(this);
 
     this.state = {
       operator: FILTER.OPERATORS.NO_OP, // Used locally to define result
@@ -112,11 +113,17 @@ class NumberFilter extends React.Component {
     }); // set a SINGLE filter
   }
 
+  OnSubmit(e) {
+    // Prevent "ENTER" from triggering form submission!
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
   render() {
     const { filterAction } = this.props;
     const { id, key, keylabel, operator, value } = this.props.filter;
     return (
-      <Form inline className="filter-item" key={id}>
+      <Form inline className="filter-item" key={id} onSubmit={this.OnSubmit}>
         <FormGroup>
           <Label size="sm" className="small text-muted"
             style={{ fontSize: '0.75em', lineHeight: '1em', width: `6em`, justifyContent: 'flex-end' }}>

--- a/build/app/view/netcreate/components/filter/NumberFilter.js
+++ b/build/app/view/netcreate/components/filter/NumberFilter.js
@@ -124,7 +124,10 @@ class NumberFilter extends React.Component {
     const { id, key, keylabel, operator, value } = this.props.filter;
     return (
       <Form inline className="filter-item" key={id} onSubmit={this.OnSubmit}>
-        <FormGroup>
+        {/* FormGroup needs to unset flexFlow or fields will overflow
+            https://getbootstrap.com/docs/4.5/utilities/flex/
+        */}
+        <FormGroup className="flex-nowrap">
           <Label size="sm" className="small text-muted"
             style={{ fontSize: '0.75em', lineHeight: '1em', width: `6em`, justifyContent: 'flex-end' }}>
             {keylabel}&nbsp;

--- a/build/app/view/netcreate/components/filter/SelectFilter.js
+++ b/build/app/view/netcreate/components/filter/SelectFilter.js
@@ -104,7 +104,7 @@ class SelectFilter extends React.Component {
       value: this.state.value,
       options
     };
-    UDATA.LocalCall('FILTER_DEFINE', {
+    if (UDATA) UDATA.LocalCall('FILTER_DEFINE', {
       group: this.props.group,
       filter,
       filterAction

--- a/build/app/view/netcreate/components/filter/SelectFilter.js
+++ b/build/app/view/netcreate/components/filter/SelectFilter.js
@@ -136,10 +136,14 @@ class SelectFilter extends React.Component {
           </Input>
           <Input type="select" value={value}
             style={{maxWidth:'12em', height:'1.5em', padding: '0'}}
-            onChange={this.OnChangeValue} bsSize="sm">
-            {options.map(op =>
-              <option value={op} key={`${id}${op}`} size="sm">{op}</option>
-            )}
+            onChange={this.OnChangeValue} bsSize="sm"
+            disabled={operator === FILTER.OPERATORS.NO_OP.key}>
+            {operator !== FILTER.OPERATORS.NO_OP.key
+              ? options.map(op =>
+                  <option value={op} key={`${id}${op}`} size="sm">{op}</option>
+                )
+              : ''
+            }
           </Input>
         </FormGroup>
       </Form>

--- a/build/app/view/netcreate/components/filter/SelectFilter.js
+++ b/build/app/view/netcreate/components/filter/SelectFilter.js
@@ -69,6 +69,7 @@ class SelectFilter extends React.Component {
     this.OnChangeOperator = this.OnChangeOperator.bind(this);
     this.OnChangeValue = this.OnChangeValue.bind(this);
     this.TriggerChangeHandler = this.TriggerChangeHandler.bind(this);
+    this.OnSubmit = this.OnSubmit.bind(this);
 
     this.state = {
       operator: FILTER.OPERATORS.NO_OP, // Used locally to define result
@@ -110,6 +111,12 @@ class SelectFilter extends React.Component {
     }); // set a SINGLE filter
   }
 
+  OnSubmit(e) {
+    // Prevent "ENTER" from triggering form submission!
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
   componentDidMount() {
     // Autoselect the first item
     this.setState({
@@ -121,7 +128,7 @@ class SelectFilter extends React.Component {
     const { filterAction } = this.props;
     const { id, key, keylabel, operator, value, options } = this.props.filter;
     return (
-      <Form inline className="filter-item" key={id}>
+      <Form inline className="filter-item" key={id} onSubmit={this.OnSubmit}>
         <FormGroup>
           <Label size="sm" className="small text-muted"
             style={{ fontSize: '0.75em', lineHeight: '1em', width: `6em`, justifyContent: 'flex-end' }}>

--- a/build/app/view/netcreate/components/filter/SelectFilter.js
+++ b/build/app/view/netcreate/components/filter/SelectFilter.js
@@ -92,6 +92,7 @@ class SelectFilter extends React.Component {
   }
 
   TriggerChangeHandler() {
+    const { filterAction } = this.props;
     const { id, type, key, keylabel, options } = this.props.filter;
     const filter = {
       id,
@@ -104,7 +105,8 @@ class SelectFilter extends React.Component {
     };
     UDATA.LocalCall('FILTER_DEFINE', {
       group: this.props.group,
-      filter
+      filter,
+      filterAction
     }); // set a SINGLE filter
   }
 
@@ -116,6 +118,7 @@ class SelectFilter extends React.Component {
   }
 
   render() {
+    const { filterAction } = this.props;
     const { id, key, keylabel, operator, value, options } = this.props.filter;
     return (
       <Form inline className="filter-item" key={id}>

--- a/build/app/view/netcreate/components/filter/SelectFilter.js
+++ b/build/app/view/netcreate/components/filter/SelectFilter.js
@@ -129,7 +129,10 @@ class SelectFilter extends React.Component {
     const { id, key, keylabel, operator, value, options } = this.props.filter;
     return (
       <Form inline className="filter-item" key={id} onSubmit={this.OnSubmit}>
-        <FormGroup>
+        {/* FormGroup needs to unset flexFlow or fields will overflow
+            https://getbootstrap.com/docs/4.5/utilities/flex/
+         */}
+        <FormGroup className="flex-nowrap">
           <Label size="sm" className="small text-muted"
             style={{ fontSize: '0.75em', lineHeight: '1em', width: `6em`, justifyContent: 'flex-end' }}>
             {keylabel}&nbsp;

--- a/build/app/view/netcreate/components/filter/StringFilter.jsx
+++ b/build/app/view/netcreate/components/filter/StringFilter.jsx
@@ -87,6 +87,7 @@ class StringFilter extends React.Component {
   }
 
   TriggerChangeHandler() {
+    const { filterAction } = this.props;
     const { id, type, key, keylabel } = this.props.filter;
     const filter = {
       id,
@@ -98,11 +99,13 @@ class StringFilter extends React.Component {
     };
     UDATA.LocalCall('FILTER_DEFINE', {
       group: this.props.group,
-      filter
+      filter,
+      filterAction
     }); // set a SINGLE filter
   }
 
   render() {
+    const { filterAction } = this.props;
     const { id, key, keylabel, operator, value } = this.props.filter;
     return (
       <Form inline className="filter-item" key={id}>

--- a/build/app/view/netcreate/components/filter/StringFilter.jsx
+++ b/build/app/view/netcreate/components/filter/StringFilter.jsx
@@ -116,7 +116,10 @@ class StringFilter extends React.Component {
     const { id, key, keylabel, operator, value } = this.props.filter;
     return (
       <Form inline className="filter-item" key={id} onSubmit={this.OnSubmit}>
-        <FormGroup>
+        {/* FormGroup needs to unset flexFlow or fields will overflow
+            https://getbootstrap.com/docs/4.5/utilities/flex/
+         */}
+        <FormGroup className="flex-nowrap">
           <Label size="sm" className="small text-muted"
             style={{ fontSize: '0.75em', lineHeight: '1em', width: `6em`, justifyContent: 'flex-end' }}>
             {keylabel}&nbsp;

--- a/build/app/view/netcreate/components/filter/StringFilter.jsx
+++ b/build/app/view/netcreate/components/filter/StringFilter.jsx
@@ -122,8 +122,9 @@ class StringFilter extends React.Component {
             )}
           </Input>
           <Input type="text" value={value} placeholder="..."
-            style={{maxWidth:'12em', height:'1.5em'}}
-            onChange={this.OnChangeValue} bsSize="sm" />
+            style={{ maxWidth: '12em', height: '1.5em' }}
+            onChange={this.OnChangeValue} bsSize="sm"
+            disabled={operator === FILTER.OPERATORS.NO_OP.key}/>
         </FormGroup>
       </Form>
     );

--- a/build/app/view/netcreate/components/filter/StringFilter.jsx
+++ b/build/app/view/netcreate/components/filter/StringFilter.jsx
@@ -64,6 +64,7 @@ class StringFilter extends React.Component {
     this.OnChangeOperator = this.OnChangeOperator.bind(this);
     this.OnChangeValue = this.OnChangeValue.bind(this);
     this.TriggerChangeHandler = this.TriggerChangeHandler.bind(this);
+    this.OnSubmit = this.OnSubmit.bind(this);
 
     this.state = {
       operator: FILTER.OPERATORS.NO_OP, // Used locally to define result
@@ -104,11 +105,17 @@ class StringFilter extends React.Component {
     }); // set a SINGLE filter
   }
 
+  OnSubmit(e) {
+    // Prevent "ENTER" from triggering form submission!
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
   render() {
     const { filterAction } = this.props;
     const { id, key, keylabel, operator, value } = this.props.filter;
     return (
-      <Form inline className="filter-item" key={id}>
+      <Form inline className="filter-item" key={id} onSubmit={this.OnSubmit}>
         <FormGroup>
           <Label size="sm" className="small text-muted"
             style={{ fontSize: '0.75em', lineHeight: '1em', width: `6em`, justifyContent: 'flex-end' }}>

--- a/build/app/view/netcreate/components/filter/StringFilter.jsx
+++ b/build/app/view/netcreate/components/filter/StringFilter.jsx
@@ -98,7 +98,7 @@ class StringFilter extends React.Component {
       operator: this.state.operator,
       value: this.state.value
     };
-    UDATA.LocalCall('FILTER_DEFINE', {
+    if (UDATA) UDATA.LocalCall('FILTER_DEFINE', {
       group: this.props.group,
       filter,
       filterAction

--- a/build/app/view/netcreate/export-logic.js
+++ b/build/app/view/netcreate/export-logic.js
@@ -111,9 +111,13 @@ function m_GenerateEdgesArray(edges, edgekeys) {
 ///////////////////////////////////////////////////////////////////////////////
 /// MODULE IMPORT / EXPORT METHODS ////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-MOD.ExportData = () => {
+
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// EXPORT NODES //////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+MOD.ExportNodes = () => {
   const DATA = UDATA.AppState('FILTEREDD3DATA');
-  const { nodes, edges } = DATA;
+  const { nodes } = DATA;
   let EXPORT = '';
 
   /// 1. Export Nodes
@@ -128,19 +132,7 @@ MOD.ExportData = () => {
   ];
   const nodesArr = m_GenerateNodesArray(nodes, nodekeys);
 
-  /// 2. Export Edges
-  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  /// Define Node KEYS
-  const edgekeys = [
-    'id',
-    'source',
-    'target',
-    { 'attributes': ['Relationship', 'Info', 'Citations', 'Category', 'Notes'] },
-    { 'meta': ['created', 'updated']}
-  ];
-  const edgesArr = m_GenerateEdgesArray(edges, edgekeys);
-
-  /// 3. Expand to CSV
+  /// 2. Expand to CSV
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   ///    3.1. NODES
   ///    3.1.1. Create headers
@@ -160,8 +152,45 @@ MOD.ExportData = () => {
   EXPORT += 'NODES\n';
   EXPORT += commaDelimitedNodes.join('\n')
 
-  ///   3.2. EDGES
-  ///   3.2.1. Create headers
+  /// 3. Save to File
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  // const encodedURI = encodeURI(EXPORT);
+  const link = document.createElement('a');
+  const blob = new Blob(["\ufeff", EXPORT]);
+  const url = URL.createObjectURL(blob);
+  link.href = url;
+  const DATASET = window.NC_CONFIG.dataset || "netcreate";
+  link.download = `${DATASET}_nodes.csv`;
+  // link.setAttribute('href', encodedURI);
+  // link.setAttribute('download', 'netcreate_export.csv');
+  document.body.appendChild(link); // Required for FF
+  link.click();
+  document.body.removeChild(link);
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// EXPORT EDGES //////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+MOD.ExportEdges = () => {
+  const DATA = UDATA.AppState('FILTEREDD3DATA');
+  const { edges } = DATA;
+  let EXPORT = '';
+
+  /// 1. Export Edges
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// Define Edge KEYS
+  const edgekeys = [
+    'id',
+    'source',
+    'target',
+    { 'attributes': ['Relationship', 'Info', 'Citations', 'Category', 'Notes'] },
+    { 'meta': ['created', 'updated']}
+  ];
+  const edgesArr = m_GenerateEdgesArray(edges, edgekeys);
+
+  /// 3. Expand to CSV
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  ///   3.1. EDGES
+  ///   3.1.1. Create headers
   const edgeHeadersArr = edgekeys.map(key => {
     // eslint-disable-next-line prefer-reflect
     if (Object.prototype.toString.call(key) === '[object Object]') {
@@ -175,7 +204,7 @@ MOD.ExportData = () => {
   edgesArr.unshift(edgeHeaders); // add headers
   ///   3.2.2 Expand Edges to CSV
   const commaDelimitedEdges = edgesArr.map(e => e.join(','));
-  EXPORT += '\n\nEDGES\n';
+  EXPORT += 'EDGES\n';
   EXPORT += commaDelimitedEdges.join('\n');
 
   /// 4. Save to File
@@ -186,14 +215,13 @@ MOD.ExportData = () => {
   const url = URL.createObjectURL(blob);
   link.href = url;
   const DATASET = window.NC_CONFIG.dataset || "netcreate";
-  link.download = `${DATASET}_export.csv`;
+  link.download = `${DATASET}_edges.csv`;
   // link.setAttribute('href', encodedURI);
   // link.setAttribute('download', 'netcreate_export.csv');
   document.body.appendChild(link); // Required for FF
   link.click();
   document.body.removeChild(link);
 }
-
 /// EXPORT CLASS DEFINITION ///////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 module.exports = MOD;

--- a/build/app/view/netcreate/export-logic.js
+++ b/build/app/view/netcreate/export-logic.js
@@ -115,6 +115,7 @@ function m_GenerateEdgesArray(edges, edgekeys) {
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// EXPORT NODES //////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// Exports FILTERED data, not the full data set.
 MOD.ExportNodes = () => {
   const DATA = UDATA.AppState('FILTEREDD3DATA');
   const { nodes } = DATA;
@@ -122,7 +123,8 @@ MOD.ExportNodes = () => {
 
   /// 1. Export Nodes
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  /// Define Node KEYS
+  /// Define Node KEYS to export
+  /// REVIEW: Should this be defined in the Template?
   const nodekeys = [
     'id',
     'label',
@@ -170,6 +172,7 @@ MOD.ExportNodes = () => {
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// EXPORT EDGES //////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// Exports FILTERED data, not the full data set.
 MOD.ExportEdges = () => {
   const DATA = UDATA.AppState('FILTEREDD3DATA');
   const { edges } = DATA;

--- a/build/app/view/netcreate/export-logic.js
+++ b/build/app/view/netcreate/export-logic.js
@@ -24,6 +24,11 @@ function m_formatDate(date) {
   return '';
 }
 
+function m_encode(data) {
+  // double quotes need to be escaped
+  return String(data).replace(/"/g, '""');
+}
+
 /// IMPORT / EXPORT METHODS ///////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -49,7 +54,7 @@ function m_getNodeValues(node, keys) {
       return;
     }
     // Else, normal processing
-    if (node.hasOwnProperty(key)) RESULT.push(`"${node[key]}"`); // enclose in quotes to support commas
+    if (node.hasOwnProperty(key)) RESULT.push(`"${m_encode(node[key])}"`); // enclose in quotes to support commas
   })
   return RESULT;
 }

--- a/build/app/view/netcreate/export-logic.js
+++ b/build/app/view/netcreate/export-logic.js
@@ -1,0 +1,199 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  * Export Logic
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+const DBG = false;
+
+/// LIBRARIES /////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const UNISYS = require("unisys/client");
+
+/// INITIALIZE MODULE /////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+var MOD = UNISYS.NewModule(module.id);
+var UDATA = UNISYS.NewDataLink(MOD);
+
+/// UTILITIES /////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+function m_formatDate(date) {
+  // wrap in quotes because time includes a comma
+  if (date) return `"${new Date(date).toUTCString()}"`;
+  return '';
+}
+
+/// IMPORT / EXPORT METHODS ///////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/ Returns an array of values for a given node record
+    e.g. [1,'Tacitus','Person',...]
+/*/
+function m_getNodeValues(node, keys) {
+  const RESULT = [];
+  keys.forEach(key => {
+    // If the key is an object, recurse
+    // eslint-disable-next-line prefer-reflect
+    if (Object.prototype.toString.call(key) === '[object Object]') {
+      const subKeys = Object.keys(key); // can have multiple subKeys
+      subKeys.forEach(k => {
+        RESULT.push( m_getNodeValues(node[k], key[k]) );
+      });
+    }
+    // Special Data Handling
+    // -- DATE
+    if (['created', 'updated'].includes(key)) {
+      RESULT.push(m_formatDate(node[key]));
+      return;
+    }
+    // Else, normal processing
+    if (node.hasOwnProperty(key)) RESULT.push(`"${node[key]}"`); // enclose in quotes to support commas
+  })
+  return RESULT;
+}
+
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/ Returns an array of node records
+    e.g. [[<tacitus>], [<marc antony>], ...]
+/*/
+function m_GenerateNodesArray(nodes, nodekeys) {
+  /// Define Node KEYS
+  const nodesArr = [];
+  nodes.forEach(n => nodesArr.push(m_getNodeValues(n, nodekeys)));
+  return nodesArr;
+}
+
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/ Returns an array of values for a given node record
+    e.g. [1,'Tacitus','Person',...]
+/*/
+function m_getEdgeValues(edge, keys) {
+  const RESULT = [];
+  keys.forEach(key => {
+    // If the key is an object, recurse
+    // eslint-disable-next-line prefer-reflect
+    if (Object.prototype.toString.call(key) === '[object Object]') {
+      const subKeys = Object.keys(key); // can have multiple subKeys
+      subKeys.forEach(k => {
+        RESULT.push( m_getNodeValues(edge[k], key[k]) );
+      });
+    }
+    // Special Data Handling
+    // -- SOURCE / TARGET
+    if (['source', 'target'].includes(key)) {
+      RESULT.push(edge[key].id);
+      return;
+    }
+    // -- DATE
+    if (['created', 'updated'].includes(key)) {
+      RESULT.push(m_formatDate(edge[key]));
+      return;
+    }
+    // Else, normal processing
+    if (edge.hasOwnProperty(key)) RESULT.push(`"${edge[key]}"`); // enclose in quotes to support commas
+  })
+  return RESULT;
+}
+
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/ Returns an array of node records
+    e.g. [ [<tacitus>], [<marc antony>], ...]
+/*/
+function m_GenerateEdgesArray(edges, edgekeys) {
+  /// Define Edge KEYS
+  const edgeArr = [];
+  edges.forEach(e => edgeArr.push(m_getEdgeValues(e, edgekeys)));
+  return edgeArr;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// MODULE IMPORT / EXPORT METHODS ////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+MOD.ExportData = () => {
+  const DATA = UDATA.AppState('FILTEREDD3DATA');
+  const { nodes, edges } = DATA;
+  let EXPORT = '';
+
+  /// 1. Export Nodes
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// Define Node KEYS
+  const nodekeys = [
+    'id',
+    'label',
+    { 'attributes': ['Node_Type', 'Extra Info', 'Notes'] },
+    'degrees',
+    { 'meta': ['created', 'updated']}
+  ];
+  const nodesArr = m_GenerateNodesArray(nodes, nodekeys);
+
+  /// 2. Export Edges
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// Define Node KEYS
+  const edgekeys = [
+    'id',
+    'source',
+    'target',
+    { 'attributes': ['Relationship', 'Info', 'Citations', 'Category', 'Notes'] },
+    { 'meta': ['created', 'updated']}
+  ];
+  const edgesArr = m_GenerateEdgesArray(edges, edgekeys);
+
+  /// 3. Expand to CSV
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  ///    3.1. NODES
+  ///    3.1.1. Create headers
+  const nodeHeadersArr = nodekeys.map(key => {
+    // eslint-disable-next-line prefer-reflect
+    if (Object.prototype.toString.call(key) === '[object Object]') {
+      const subKeys = Object.keys(key); // can have multiple subKeys
+      return subKeys.map(sk => key[sk].map(k => `${sk}:${k}`)).flat();
+    } else {
+      return key;
+    }
+  });
+  const nodeHeaders = nodeHeadersArr.flat();
+  nodesArr.unshift(nodeHeaders); // add headers
+  ///    3.1.2. Expand Nodes to CSV
+  const commaDelimitedNodes = nodesArr.map(n => n.join(','));
+  EXPORT += 'NODES\n';
+  EXPORT += commaDelimitedNodes.join('\n')
+
+  ///   3.2. EDGES
+  ///   3.2.1. Create headers
+  const edgeHeadersArr = edgekeys.map(key => {
+    // eslint-disable-next-line prefer-reflect
+    if (Object.prototype.toString.call(key) === '[object Object]') {
+      const subKeys = Object.keys(key); // can have multiple subKeys
+      return subKeys.map(sk => key[sk].map(k => `${sk}:${k}`)).flat();
+    } else {
+      return key;
+    }
+  });
+  const edgeHeaders = edgeHeadersArr.flat();
+  edgesArr.unshift(edgeHeaders); // add headers
+  ///   3.2.2 Expand Edges to CSV
+  const commaDelimitedEdges = edgesArr.map(e => e.join(','));
+  EXPORT += '\n\nEDGES\n';
+  EXPORT += commaDelimitedEdges.join('\n');
+
+  /// 4. Save to File
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  // const encodedURI = encodeURI(EXPORT);
+  const link = document.createElement('a');
+  const blob = new Blob(["\ufeff", EXPORT]);
+  const url = URL.createObjectURL(blob);
+  link.href = url;
+  const DATASET = window.NC_CONFIG.dataset || "netcreate";
+  link.download = `${DATASET}_export.csv`;
+  // link.setAttribute('href', encodedURI);
+  // link.setAttribute('download', 'netcreate_export.csv');
+  document.body.appendChild(link); // Required for FF
+  link.click();
+  document.body.removeChild(link);
+}
+
+/// EXPORT CLASS DEFINITION ///////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+module.exports = MOD;

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -113,8 +113,7 @@ MOD.Hook("INITIALIZE", () => {
   UDATA.OnAppStateChange("FDATA", data => {
     if (DBG) console.log(PR + 'OnAppStateChange: FDATA', data);
     // The filter defs have been updated, so apply the filters.
-    m_FiltersApply();
-    m_UpdateFilterSummary();
+    m_UpdateFilters();
   });
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -130,6 +129,22 @@ MOD.Hook("INITIALIZE", () => {
   UDATA.HandleMessage("FILTER_CLEAR", () => {
     m_ClearFilters();
   });
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /*/ FILTERS_UPDATE is called by FiltersPanel switches between filters and highlights
+  /*/
+  UDATA.HandleMessage("FILTERS_UPDATE", data => {
+    const FDATA = UDATA.AppState("FDATA");
+    FDATA.filterAction = data.filterAction;
+    UDATA.SetAppState("FDATA", FDATA);
+  });
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /*/     // Listen for D3DATA updates so we know to trigger change?
+  /*/
+  UDATA.OnAppStateChange('D3DATA',(data)=>{
+    m_UpdateFilters();
+  });
+
 
 }); // end UNISYS_INIT
 
@@ -234,12 +249,12 @@ function m_ImportPrompts(prompts) {
  */
 function m_FilterDefine(data) {
   const FDATA = UDATA.AppState("FDATA");
+  FDATA.filterAction = data.filterAction;
   if (data.group === "nodes") {
 
     if (data.type === "transparency")
     {
       FDATA.nodes.transparency = data.transparency;
-
     }
     else{
       let nodeFilters = FDATA.nodes.filters;
@@ -295,6 +310,11 @@ function m_UpdateFilterSummary() {
   UDATA.LocalCall('FILTER_SUMMARY_UPDATE', { filtersSummary: summary });
 }
 
+function m_UpdateFilters() {
+  m_FiltersApply();
+  m_UpdateFilterSummary();
+}
+
 function m_FiltersToString(filters) {
   let summary = ''
   filters.forEach(filter => {
@@ -310,6 +330,7 @@ function m_FiltersToString(filters) {
 function m_OperatorToString(operator) {
   return FILTER.OPERATORS[operator].label;
 }
+
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/ UTILITY FUNCTIONS
 /*/

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -48,9 +48,10 @@
         "Filter" shows matching nodes/edges and removes the non-matching
         nodes/edges from the display without affecting the underlying data.
 
-  * With Version 1.4, the only data that is graphed is FILTERED_D3DATA.
+  * With Version 1.4, the only data that is graphed is FILTEREDD3DATA.
     --  d3-simplenetgraph no longer plots on D3DATA changes.
-    --  Instead, FILTERED_D3DATA changes are pushed via an AppCall.
+    --  Instead, it plots the new FILTEREDD3DATA state.  Whenever D3DATA changes,
+        FILTERDD3DATA is udpated.
     --  This way there is only one source of truth: all draw updates
         are routed through filter-logic.
     --  If filters have not been defined, we just pass the raw D3DATA
@@ -461,7 +462,7 @@ function m_NodeIsFiltered(node, filters, transparency, filterAction) {
   }
 
   // all_no_op
-  // Thjs is currently redundant because matchesFilter will always
+  // This is currently redundant because matchesFilter will always
   // be true if there are no filters.  If matchesFilter is true,
   // then the node will not be removed/faded.
   //

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -301,16 +301,17 @@ function m_FilterDefine(data) {
  * @param {Object} data A UDATA pkt {defs}
  */
 function m_FiltersApply() {
-  const FILTERED_D3DATA = UDATA.AppState("D3DATA");
+  const FILTEREDD3DATA = UDATA.AppState("D3DATA");
   const FDATA = UDATA.AppState("FDATA");
 
   // skip if FDATA has not been defined yet
   if (Object.keys(FDATA).length < 1) return;
 
-  m_FiltersApplyToNodes(FDATA, FILTERED_D3DATA);
-  m_FiltersApplyToEdges(FDATA, FILTERED_D3DATA);
-  // Update FILTERED_D3DATA
-  UDATA.Call("FILTERED_D3DATA", FILTERED_D3DATA);
+  m_FiltersApplyToNodes(FDATA, FILTEREDD3DATA);
+  m_FiltersApplyToEdges(FDATA, FILTEREDD3DATA);
+  // Update FILTEREDD3DATA
+  UDATA.SetAppState("FILTEREDD3DATA", FILTEREDD3DATA);
+
 }
 
 function m_ClearFilters() {
@@ -417,15 +418,15 @@ function m_MatchNumber(operator, filterVal, objVal) {
 
 /**
  * Side effect:
- *   FILTERED_D3DATA.nodes are updated with `isFilteredOut` flags.
+ *   FILTEREDD3DATA.nodes are updated with `isFilteredOut` flags.
  *
  * @param {Array} filters
  */
-function m_FiltersApplyToNodes(FDATA, FILTERED_D3DATA) {
+function m_FiltersApplyToNodes(FDATA, FILTEREDD3DATA) {
   const { filterAction } = FDATA;
   const { filters, transparency } = FDATA.nodes;
-  FILTERED_D3DATA.nodes = FILTERED_D3DATA.nodes.filter(node => {
-    return m_FiltersApplyToNode(node, filters, transparency, filterAction);
+  FILTEREDD3DATA.nodes = FILTEREDD3DATA.nodes.filter(node => {
+    return m_NodeIsFiltered(node, filters, transparency, filterAction);
   });
 }
 
@@ -500,11 +501,11 @@ function m_IsNodeMatchedByFilter(node, filter) {
 /*/ EDGE FILTERS
 /*/
 
-function m_FiltersApplyToEdges(FDATA, FILTERED_D3DATA) {
+function m_FiltersApplyToEdges(FDATA, FILTEREDD3DATA) {
   const { filterAction } = FDATA;
   const { filters, transparency } = FDATA.edges;
-  FILTERED_D3DATA.edges = FILTERED_D3DATA.edges.filter(edge => {
-    return m_FiltersApplyToEdge(edge, filters, transparency, filterAction);
+  FILTEREDD3DATA.edges = FILTEREDD3DATA.edges.filter(edge => {
+    return m_EdgeIsFiltered(edge, filters, transparency, filterAction, FILTEREDD3DATA);
   });
 }
 

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -335,7 +335,8 @@ function m_UpdateFilterSummary() {
   const nodeSummary = m_FiltersToString(FDATA.nodes.filters);
   const edgeSummary = m_FiltersToString(FDATA.edges.filters);
   let summary = '';
-  if (nodeSummary || edgeSummary) summary = `${typeSummary} NODES: ${nodeSummary} EDGES: ${edgeSummary}`;
+  if (nodeSummary || edgeSummary) summary =
+    `${typeSummary} ${nodeSummary ? 'NODES: ' : ''}${nodeSummary} ${edgeSummary ? 'EDGES: ' : ''}${edgeSummary}`;
 
   UDATA.LocalCall('FILTER_SUMMARY_UPDATE', { filtersSummary: summary });
 }

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -42,7 +42,7 @@
 
   * See Whimiscal [diagram](https://whimsical.com/d3-data-flow-B2tTGnQYPSNviUhsPL64Dz)
 
-  * "Highlight" vs "Filter"
+  * filterAction: "Highlight" vs "Filter"
     --  Version 1.4 introduces two different types of filtering:
         "Highlight" highlights the matching nodes/edges and fades the others
         "Filter" shows matching nodes/edges and removes the non-matching

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -392,13 +392,16 @@ function m_FiltersApplyToNode(node, filters, transparency) {
     }
   });
   if (all_no_op) {
-    // no filters defined, undo isFilteredOut
-    node.isFilteredOut = false;
+    // all filters are "no_op", so no filters defined, don't filter anything
+    node.filteredTransparency = 1.0; // opaque, not tranparent
   } else {
     // node is filtered out if it fails any filter tests
-    node.isFilteredOut = !matched;
-
-    node.filteredTransparency = transparency; // set the transparency value ... right now it is inefficient to set this at the node / edge level, but that's more flexible
+    if (!matched) {
+      node.filteredTransparency = transparency; // set the transparency value ... right now it is inefficient to set this at the node / edge level, but that's more flexible
+    } else {
+      node.filteredTransparency = 1.0; // opaque
+    }
+  }
 
   }
 }
@@ -471,11 +474,16 @@ function m_FiltersApplyToEdge(edge, filters, transparency) {
   });
   if (all_no_op) {
     // no filters defined, undo isFilteredOut
-    edge.isFilteredOut = false;
+    edge.filteredTransparency = 1.0;
   } else {
     // edge is filtered out if it fails ANY filter tests
-    edge.isFilteredOut = !matched;
-    edge.filteredTransparency = transparency;; // set the transparency value ... right now it is inefficient to set this at the node / edge level, but that's more flexible
+    if (!matched) {
+      edge.filteredTransparency = transparency; // set the transparency value ... right now it is inefficient to set this at the node / edge level, but that's more flexible
+    } else {
+      edge.filteredTransparency = 1.0; // opaque
+    }
+  }
+
 
   }
 }

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -40,6 +40,8 @@
 
   FEATURES
 
+  * See Whimiscal [diagram](https://whimsical.com/d3-data-flow-B2tTGnQYPSNviUhsPL64Dz)
+
   * "Highlight" vs "Filter"
     --  Version 1.4 introduces two different types of filtering:
         "Highlight" highlights the matching nodes/edges and fades the others
@@ -326,10 +328,12 @@ function m_UpdateFilterSummary() {
   const nodeFilters = FDATA.nodes.filters;
   const edgeFilters = FDATA.edges.filters;
 
-  let summary = FDATA.filterAction === FILTER.ACTION.HIGHLIGHT
+  const typeSummary = FDATA.filterAction === FILTER.ACTION.HIGHLIGHT
     ? 'HIGHLIGHTING ' : 'FILTERING ';
-  summary += m_FiltersToString(FDATA.nodes.filters);
-  summary += m_FiltersToString(FDATA.edges.filters);
+  const nodeSummary = m_FiltersToString(FDATA.nodes.filters);
+  const edgeSummary = m_FiltersToString(FDATA.edges.filters);
+  let summary = '';
+  if (nodeSummary || edgeSummary) summary = `${typeSummary} NODES: ${nodeSummary} EDGES: ${edgeSummary}`;
 
   UDATA.LocalCall('FILTER_SUMMARY_UPDATE', { filtersSummary: summary });
 }

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -265,7 +265,7 @@ function m_ImportPrompts(prompts) {
  */
 function m_FilterDefine(data) {
   const FDATA = UDATA.AppState("FDATA");
-  FDATA.filterAction = data.filterAction;
+  FDATA.filterAction = data.filterAction || FDATA.filterAction; // if 'transparency' then filterAction is not passed, so default to existing
   if (data.group === "nodes") {
 
     if (data.type === "transparency")

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -40,6 +40,19 @@
 
   FEATURES
 
+  * "Highlight" vs "Filter"
+    --  Version 1.4 introduces two different types of filtering:
+        "Highlight" highlights the matching nodes/edges and fades the others
+        "Filter" shows matching nodes/edges and removes the non-matching
+        nodes/edges from the display without affecting the underlying data.
+
+  * With Version 1.4, the only data that is graphed is FILTERED_D3DATA.
+    --  d3-simplenetgraph no longer plots on D3DATA changes.
+    --  Instead, FILTERED_D3DATA changes are pushed via an AppCall.
+    --  This way there is only one source of truth: all draw updates
+        are routed through filter-logic.
+    --  If filters have not been defined, we just pass the raw D3DATA
+
   * Filters can be stacked.
         You can define two "Label" filters, for example.
         The only reason you can't do it right now is because the filter template

--- a/build/app/view/netcreate/nc-logic.js
+++ b/build/app/view/netcreate/nc-logic.js
@@ -43,6 +43,7 @@ const SETTINGS = require("settings");
 const UNISYS = require("unisys/client");
 const JSCLI = require("system/util/jscli");
 const D3 = require("d3");
+const EXPORT = require("./export-logic");
 
 /// INITIALIZE MODULE /////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -673,6 +674,13 @@ MOD.Hook("INITIALIZE", () => {
   /*/
   UDATA.HandleMessage("AUTOCOMPLETE_SELECT", function(data) {
     m_HandleAutoCompleteSelect(data);
+  });
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - inside hook
+  /*/
+  /*/
+  UDATA.HandleMessage("EXPORT", data => {
+    EXPORT.ExportData();
   });
 
 }); // end UNISYS_INIT

--- a/build/app/view/netcreate/nc-logic.js
+++ b/build/app/view/netcreate/nc-logic.js
@@ -221,6 +221,7 @@ MOD.Hook("LOADASSETS", () => {
 /*/ CONFIGURE fires after LOADASSETS, so this is a good place to put TEMPLATE
     validation.
 /*/
+// eslint-disable-next-line complexity
 MOD.Hook("CONFIGURE", () => {
   // Process Node, NodeColorMap and Edge options
 

--- a/build/app/view/netcreate/nc-logic.js
+++ b/build/app/view/netcreate/nc-logic.js
@@ -679,8 +679,11 @@ MOD.Hook("INITIALIZE", () => {
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - inside hook
   /*/
   /*/
-  UDATA.HandleMessage("EXPORT", data => {
-    EXPORT.ExportData();
+  UDATA.HandleMessage("EXPORT_NODES", data => {
+    EXPORT.ExportNodes();
+  });
+  UDATA.HandleMessage("EXPORT_EDGES", data => {
+    EXPORT.ExportEdges();
   });
 
 }); // end UNISYS_INIT


### PR DESCRIPTION
IMPORTANT: Merge #169 before merging this!
---

# To Do

* [x] Export as two files dataset_nodes.csv / dataset_edges.csv
* [x] Combine "Vocabulary" and "Help" as "More"
* [x] Add TOC for "More"
* [ ] Collapsible Search/Node
* [x] Autocollapse Search/Node when Filter is opened for smaller screens
* [x] Filter display in collapsible right panel

---

This implements #177.

Branch: `dev-bl/export`

This adds the ability to Export and download a CSV file to a local file.

# Prototype Implementation

Currently this takes a preliminary approach to exporting.  We can work out exactly how you want this to work.

#### To Test

1. `git fetch; git checkout dev-bl/export`
2.  Start NetCreate with your own data, e.g. `./nc.js --dataset=junk`
3. Go to `http://localhost:3000`
4. Log in if necessary
5. Click the "Help" tab
6. Click the "Export" button.
7. Set the download name.
8. Click "Save" to save the CSV file to your local hard drive.
9. Open the CSV in Excel

#### Where to put the Export button?
There is now an "Export" button in the "Help" tab.

I didn't want to add another tab because we already had so many tabs and on narrower windows the tabs do not flow well.  We can revisit where to put the button 

#### What is exported?
To keep things simple, we currently just export whatever is being drawn on the graph.  Any nodes/edges that are filtered are not exported.  Any nodes/edges that are highlighted ARE exported but there is no marker to indicate that they are highlighted.

We can add a second button "EXPORT FILTERED DATA" to "EXPORT DATA" if you think we need that distinction.

#### What is the export format?
Rather than exporting two separate files, I've put all the data in one file, something like this:
```
NODES
<node headers>
<nodes>

EDGES
<edge headers>
<edges>
```
It seems more convenient to be able to keep things in a single file.  You can easily copy and paste to move them as needed.

If they should be exported as two separate files, let me know.

#### What is the CSV format?
Currently we're just building up the nodes and edges data based on the data in the database.  The specific fields that are exported can easily be configured via the code.  But right now there is no end-user customization available.  

It's not clear we want to support end-user customization as that can get pretty complicated.  The issue is that the data is not a simple flat table but consists of nested fields, so creating the index for the fields is something only an expert should do.

#### How to handle 'attributes' fields?
Our file format uses nested attributes fields for each node/edge record.  I believe this came from whichever package we were originally importing the data from (Gephy?).  e.g. a node record might look like this:
```
node = {
  id,
  label,
  attributes: {
    Node_Type,
    Extra Info,
    Notes,
  }
}
```
When exporting the data, we flatten out the data so that everything can fit within a single record.  We do this by adding the 'attributes' tag to the field names, e.g. we have `attributes:Node_Type`, attributes:Extra Info`, and `attributes:Notes`, e.g.:
```
node = [
  id,
  label,
  attributes:Node_Type,
  attributes:Extra Info,
  attributes:Notes
]
```
Let me know if you need a different way of handling that data.

#### How are source and targets referenced in Edge nodes?
Currently, we're using numeric IDs to reference source and targets in edges.  We can also add labels if needed, but that does get more complicated.  Using ids seemed like the most efficient format.

Let me know if you need labels as well.

#### How to handle Commas, Quotes, and Special Characters?
To keep things simple, right now all fields are wrapped in double quotes ("") which should theoretically support commas in descriptions.  We can strip out other characters if needed, but I wasn't sure how aggressive we should be.  

The critical symbols are probably:
* commas
* double quotes -- depending on the application reading the final csv, we might be able to replace double quotes with single quotes, or otherwise encode them.
* line feeds/carriage returns -- how do you want to preserve these?  line feeds are the record delimiters in CSV.
* control characters

I expect to tackle the encoding issues later.

#### How to set the default filename?
By default, the filename is '<datsetname>_export.csv'.  We can use a different default filename if you prefer.

#### How to display date and time?
Both nodes and edges keep track of `created` and `updated` date and time information.  We export the created and updated dates in UTC format.  We can relatively easily select a different format if you prefer.  Or of course we can remove dates altogether.

```
Thu, 11 Nov 2021 23:56:54 GMT
```

Any other issues?



