### PR TITLE
Hotifix: Set Markdown Image Width

### DIFF
--- a/build/app/view/netcreate/components/NodeSelector.css
+++ b/build/app/view/netcreate/components/NodeSelector.css
@@ -1,7 +1,10 @@
+/* Auto-compiled and included by brunch */
+
 .warning {
   padding: 5px 0
 }
 
-.nodeEntry img {
+/* Applies to both NodeSelector, EdgeEditor, NodeTable, and EdgeTable */
+.nodeEntry img, .table img {
   max-width: 100%
 }

--- a/build/app/view/netcreate/components/NodeSelector.css
+++ b/build/app/view/netcreate/components/NodeSelector.css
@@ -1,3 +1,7 @@
 .warning {
   padding: 5px 0
 }
+
+.nodeEntry img {
+  max-width: 100%
+}


### PR DESCRIPTION
# Merge after #217!!!

This addresses #214.

Add css to set the max width of any images under `.nodeEntry` to 100%.  This should make them fit within the editor boundary.  Any node field or edit field should be a child class of `.nodeEntry`.
