### PR TITLE
Feature: Collapse Filter

### DIFF
--- a/build/app/view/netcreate/NetCreate.jsx
+++ b/build/app/view/netcreate/NetCreate.jsx
@@ -53,6 +53,7 @@ const InfoPanel    = require('./components/InfoPanel');
 const FiltersPanel = require('./components/filter/FiltersPanel');
 const NCLOGIC      = require('./nc-logic'); // require to bootstrap data loading
 const FILTERLOGIC  = require('./filter-logic'); // handles filtering functions
+const FILTER = require('./components/filter/FilterEnums');
 
 /// REACT COMPONENT ///////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -195,7 +196,7 @@ const FILTERLOGIC  = require('./filter-logic'); // handles filtering functions
                       <Button onClick={this.onFilterBtnClick}
                         style={{ width: '90px' }}
                       >
-                        FILTER &gt;
+                        {FILTER.PANEL_LABEL} &gt;
                       </Button>
                       <FiltersPanel />
                     </div>
@@ -208,7 +209,7 @@ const FILTERLOGIC  = require('./filter-logic'); // handles filtering functions
                     <Button
                       onClick={this.onFilterBtnClick}
                       style={{ width: '90px', float: 'right' }}
-                    >&lt; FILTER</Button>
+                    >&lt; {FILTER.PANEL_LABEL}</Button>
                   </div>
               }
             </div>

--- a/build/app/view/netcreate/components/EdgeTable.jsx
+++ b/build/app/view/netcreate/components/EdgeTable.jsx
@@ -199,7 +199,19 @@ class EdgeTable extends UNISYS.Component {
   handleFilterDataUpdate(data) {
     if (data.edges) {
       const filteredEdges = data.edges;
-      this.setState({ filteredEdges }, () => {
+
+      // OLD METHOD: Keep a pure edges object, and apply filtering to them
+      // this.setState({ filteredEdges }, () => {
+      //   const edges = this.sortTable(this.state.sortkey, this.state.edges);
+      //   this.updateEdgeFilterState(edges, filteredEdges);
+      // });
+
+      // NEW METHOD: Just replace pure edges with filtered edges
+      //             This way edges that have been filtered out are also removed from the table
+      this.setState({
+        edges: filteredEdges,
+        filteredEdges
+      }, () => {
         const edges = this.sortTable(this.state.sortkey, this.state.edges);
         this.updateEdgeFilterState(edges, filteredEdges);
       });

--- a/build/app/view/netcreate/components/EdgeTable.jsx
+++ b/build/app/view/netcreate/components/EdgeTable.jsx
@@ -193,7 +193,7 @@ class EdgeTable extends UNISYS.Component {
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /*/ Handle FILTEREDD3DATA updates sent by filters-logic.m_FiltersApply
-      Note that edge.soourceLabel and edge.targetLabe should already be set
+      Note that edge.soourceLabel and edge.targetLabel should already be set
       by filter-logic.
   /*/
   handleFilterDataUpdate(data) {

--- a/build/app/view/netcreate/components/EdgeTable.jsx
+++ b/build/app/view/netcreate/components/EdgeTable.jsx
@@ -546,7 +546,7 @@ class EdgeTable extends UNISYS.Component {
                       onClick={()=>this.setSortKey("Updated", FILTER.TYPES.STRING)}
                     >Updated {this.sortSymbol("Updated")}</Button></th>
                 <th  width="10%"hidden={edgeDefs.comments.hidden}><Button size="sm"
-                      onClick={()=>this.setSortKey("comments", edgeDefs.comment.type)}
+                      onClick={()=>this.setSortKey("comments", edgeDefs.comments.type)}
                     >{edgeDefs.comments.displayLabel} {this.sortSymbol("comments")}</Button></th>
               </tr>
             </thead>

--- a/build/app/view/netcreate/components/NodeTable.jsx
+++ b/build/app/view/netcreate/components/NodeTable.jsx
@@ -175,7 +175,19 @@ class NodeTable extends UNISYS.Component {
   handleFilterDataUpdate(data) {
     if (data.nodes) {
       const filteredNodes = data.nodes;
-      this.setState({ filteredNodes }, () => {
+
+      // OLD METHOD: Keep a pure nodes object, and apply filtering to them
+      // this.setState({ filteredNodes }, () => {
+      //   const nodes = this.sortTable(this.state.sortkey, this.state.nodes);
+      //   this.updateNodeFilterState(nodes, filteredNodes);
+      // });
+
+      // NEW METHOD: Just replace pure nodes with filtered nodes
+      //             This way nodes that have been filtered out are also removed from the table
+      this.setState({
+        nodes: filteredNodes,
+        filteredNodes
+      }, () => {
         const nodes = this.sortTable(this.state.sortkey, this.state.nodes);
         this.updateNodeFilterState(nodes, filteredNodes);
       });

--- a/build/app/view/netcreate/components/filter/FilterEnums.js
+++ b/build/app/view/netcreate/components/filter/FilterEnums.js
@@ -1,5 +1,8 @@
 const FILTER = {};
 
+// Filter Panel Label
+FILTER.PANEL_LABEL = 'VIEWS';
+
 // Determines whether filter action is to highlight/fade or remove (filter) nodes and edges
 FILTER.ACTION = {};
 FILTER.ACTION.HIGHLIGHT = 'HIGHLIGHTING';

--- a/build/app/view/netcreate/components/filter/FilterEnums.js
+++ b/build/app/view/netcreate/components/filter/FilterEnums.js
@@ -2,8 +2,12 @@ const FILTER = {};
 
 // Determines whether filter action is to highlight/fade or remove (filter) nodes and edges
 FILTER.ACTION = {};
-FILTER.ACTION.HIGHLIGHT = 'highlight';
-FILTER.ACTION.FILTER = 'filter';
+FILTER.ACTION.HIGHLIGHT = 'HIGHLIGHTING';
+FILTER.ACTION.FILTER = 'FILTERING';
+FILTER.ACTION.HELP = {};
+FILTER.ACTION.HELP.HIGHLIGHT = 'Show (Highlight) matches, Fade others';
+FILTER.ACTION.HELP.FILTER = 'Shows matches, Hide (Filter) others (keep physics and degrees)';
+FILTER.ACTION.HELP.COLLAPSE = 'Show matches, Remove (collapse) others & recalculate sizes';
 
 // Types of filters definable in template files.
 FILTER.TYPES = {};

--- a/build/app/view/netcreate/components/filter/FilterEnums.js
+++ b/build/app/view/netcreate/components/filter/FilterEnums.js
@@ -4,6 +4,7 @@ const FILTER = {};
 FILTER.ACTION = {};
 FILTER.ACTION.HIGHLIGHT = 'HIGHLIGHTING';
 FILTER.ACTION.FILTER = 'FILTERING';
+FILTER.ACTION.COLLAPSE = 'COLLAPSING';
 FILTER.ACTION.HELP = {};
 FILTER.ACTION.HELP.HIGHLIGHT = 'Show (Highlight) matches, Fade others';
 FILTER.ACTION.HELP.FILTER = 'Shows matches, Hide (Filter) others (keep physics and degrees)';

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -45,7 +45,8 @@ class FiltersPanel extends UNISYS.Component {
     this.state = {
       nodes: FDATA.nodes,
       edges: FDATA.edges,
-      filterAction: FILTER.ACTION.HIGHLIGHT
+      filterAction: FILTER.ACTION.HIGHLIGHT,
+      filterActionHelp: FILTER.ACTION.HELP.HIGHLIGHT
     };
     UDATA.OnAppStateChange("FDATA", this.UpdateFilterDefs);
   } // constructor
@@ -60,7 +61,8 @@ class FiltersPanel extends UNISYS.Component {
       return {
         nodes: data.nodes,
         edges: data.edges,
-        filterAction: data.filterAction || state.filterAction
+        filterAction: data.filterAction || state.filterAction,
+        filterActionHelp: data.filterActionHelp || state.filterActionHelp
       }
     });
   }
@@ -70,12 +72,15 @@ class FiltersPanel extends UNISYS.Component {
   }
 
   SelectFilterAction(filterAction) {
-    this.setState({ filterAction });
+    let filterActionHelp;
+    if (filterAction === FILTER.ACTION.HIGHLIGHT) filterActionHelp = FILTER.ACTION.HELP.HIGHLIGHT;
+    if (filterAction === FILTER.ACTION.FILTER) filterActionHelp = FILTER.ACTION.HELP.FILTER;
+    this.setState({ filterAction, filterActionHelp });
     UDATA.LocalCall('FILTERS_UPDATE', { filterAction });
   }
 
   render() {
-    const { filterAction } = this.state;
+    const { filterAction, filterActionHelp } = this.state;
     const defs = [this.state.nodes, this.state.edges];
     return (
       <div className="filterPanel"
@@ -109,10 +114,7 @@ class FiltersPanel extends UNISYS.Component {
           >Filter</Button>
         </ButtonGroup>
         <Label className="small text-muted" style={{ padding: '0.5em 0 0 0.5em', marginBottom: '0' }}>
-          {filterAction === FILTER.ACTION.HIGHLIGHT
-            ? 'Highlight nodes/edges that match criteria. (Fade others)'
-            : 'Filter shows only nodes/edges that match criteria.  (Removes others)'
-          }
+          {filterActionHelp}
         </Label>
         <hr/>
         <div style={{ display: 'flex', flexDirection: 'column', flexGrow: `1`, justifyContent: 'space-evenly' }}>

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -103,6 +103,7 @@ class FiltersPanel extends UNISYS.Component {
               backgroundColor: filterAction === FILTER.ACTION.HIGHLIGHT ? 'transparent' : '#6c757d88'
             }}
           >Highlight</Button>
+          {/* Hide "Filter" panel.  We will probably remove this functionality.
           <Button
             onClick={() => this.SelectFilterAction(FILTER.ACTION.FILTER)}
             active={filterAction === FILTER.ACTION.FILTER}
@@ -112,7 +113,7 @@ class FiltersPanel extends UNISYS.Component {
               color: filterAction === FILTER.ACTION.FILTER ? '#333' : '#fff',
               backgroundColor: filterAction === FILTER.ACTION.FILTER ? 'transparent' : '#6c757d88'
             }}
-          >Filter</Button>
+          >Filter</Button> */}
           <Button
             onClick={() => this.SelectFilterAction(FILTER.ACTION.COLLAPSE)}
             active={filterAction === FILTER.ACTION.COLLAPSE}

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -75,6 +75,7 @@ class FiltersPanel extends UNISYS.Component {
     let filterActionHelp;
     if (filterAction === FILTER.ACTION.HIGHLIGHT) filterActionHelp = FILTER.ACTION.HELP.HIGHLIGHT;
     if (filterAction === FILTER.ACTION.FILTER) filterActionHelp = FILTER.ACTION.HELP.FILTER;
+    if (filterAction === FILTER.ACTION.COLLAPSE) filterActionHelp = FILTER.ACTION.HELP.COLLAPSE;
     this.setState({ filterAction, filterActionHelp });
     UDATA.LocalCall('FILTERS_UPDATE', { filterAction });
   }
@@ -112,6 +113,16 @@ class FiltersPanel extends UNISYS.Component {
               backgroundColor: filterAction === FILTER.ACTION.FILTER ? 'transparent' : '#6c757d88'
             }}
           >Filter</Button>
+          <Button
+            onClick={() => this.SelectFilterAction(FILTER.ACTION.COLLAPSE)}
+            active={filterAction === FILTER.ACTION.COLLAPSE}
+            outline={filterAction === FILTER.ACTION.COLLAPSE}
+            disabled={filterAction === FILTER.ACTION.COLLAPSE}
+            style={{
+              color: filterAction === FILTER.ACTION.COLLAPSE ? '#333' : '#fff',
+              backgroundColor: filterAction === FILTER.ACTION.COLLAPSE ? 'transparent' : '#6c757d88'
+            }}
+          >Collapse</Button>
         </ButtonGroup>
         <Label className="small text-muted" style={{ padding: '0.5em 0 0 0.5em', marginBottom: '0' }}>
           {filterActionHelp}

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -333,8 +333,7 @@ function m_UpdateFilterSummary() {
   const nodeFilters = FDATA.nodes.filters;
   const edgeFilters = FDATA.edges.filters;
 
-  const typeSummary = FDATA.filterAction === FILTER.ACTION.HIGHLIGHT
-    ? 'HIGHLIGHTING ' : 'FILTERING ';
+  const typeSummary = FDATA.filterAction; // text for filter action is the label, e.g. 'HIGHLIGHT'
   const nodeSummary = m_FiltersToString(FDATA.nodes.filters);
   const edgeSummary = m_FiltersToString(FDATA.edges.filters);
   let summary = '';

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -557,7 +557,7 @@ function m_EdgeIsFiltered(edge, filters, transparency, filterAction, FILTEREDD3D
   if (source === undefined || target === undefined ) return false;
 
   // 2. If source or target have been removed via collapse, remove the edge
-  if (removedNodes.includes(source.id) || removedNodes.includes(edge.id)) return false;
+  if (removedNodes.includes(source.id) || removedNodes.includes(target.id)) return false;
   // 3. if source or target is transparent, then we are transparent too
   if ( source.filteredTransparency < 1.0 ||
        target.filteredTransparency < 1.0) {

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -316,11 +316,16 @@ function m_FiltersApply() {
   m_FiltersApplyToNodes(FDATA, FILTEREDD3DATA);
   m_FiltersApplyToEdges(FDATA, FILTEREDD3DATA);
 
+
+
+  // REVIEW 2023-0530
+  // -- If "Filter/Hide" functionality is going to be kept, this needs to be reworked!
+  //    We SHOULD NOT recalculate sizes in "Filter/Hide" mode, otherwise, the size will change.
+  //
   // Recalculate sizes
-  if ( FDATA.filterAction === FILTER.ACTION.COLLAPSE) {
-    UTILS.RecalculateAllEdgeSizes(FILTEREDD3DATA);
-    UTILS.RecalculateAllNodeDegrees(FILTEREDD3DATA);
-  }
+  // ALWAYS recalculate, e.g. if switching from Collapse to Highlight or clearing data
+  UTILS.RecalculateAllEdgeSizes(FILTEREDD3DATA);
+  UTILS.RecalculateAllNodeDegrees(FILTEREDD3DATA);
 
   // Update FILTEREDD3DATA
   UDATA.SetAppState("FILTEREDD3DATA", FILTEREDD3DATA);

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -81,6 +81,7 @@
 import FILTER from './components/filter/FilterEnums';
 const UNISYS = require("unisys/client");
 const clone = require("rfdc")();
+const UTILS = require("./nc-utils");
 
 /// INITIALIZE MODULE /////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -97,6 +98,7 @@ var FDATA_RESTORE; // pristine FDATA for clearing
 let NODE_DEFAULT_TRANSPARENCY;
 let EDGE_DEFAULT_TRANSPARENCY;
 
+let removedNodes = []; // nodes removed via COLLAPSE filter action
 
 /// CONSTANTS /////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -313,6 +315,13 @@ function m_FiltersApply() {
 
   m_FiltersApplyToNodes(FDATA, FILTEREDD3DATA);
   m_FiltersApplyToEdges(FDATA, FILTEREDD3DATA);
+
+  // Recalculate sizes
+  if ( FDATA.filterAction === FILTER.ACTION.COLLAPSE) {
+    UTILS.RecalculateAllEdgeSizes(FILTEREDD3DATA);
+    UTILS.RecalculateAllNodeDegrees(FILTEREDD3DATA);
+  }
+
   // Update FILTEREDD3DATA
   UDATA.SetAppState("FILTEREDD3DATA", FILTEREDD3DATA);
 
@@ -427,6 +436,7 @@ function m_MatchNumber(operator, filterVal, objVal) {
  * @param {Array} filters
  */
 function m_FiltersApplyToNodes(FDATA, FILTEREDD3DATA) {
+  removedNodes = [];
   const { filterAction } = FDATA;
   const { filters, transparency } = FDATA.nodes;
   FILTEREDD3DATA.nodes = FILTEREDD3DATA.nodes.filter(node => {
@@ -454,14 +464,21 @@ function m_NodeIsFiltered(node, filters, transparency, filterAction) {
     node.filteredTransparency = NODE_DEFAULT_TRANSPARENCY; // opaque, not transparent
     if (keepNode) return true;
     return false; // remove from array
-  } else {
-    // FILTER.ACTION.HIGHLIGHT
+  } else if (filterAction === FILTER.ACTION.HIGHLIGHT) {
     if (!keepNode) {
       node.filteredTransparency = transparency; // set the transparency value ... right now it is inefficient to set this at the node / edge level, but that's more flexible
     } else {
       node.filteredTransparency = NODE_DEFAULT_TRANSPARENCY; // opaque
     }
     return true; // don't filter out
+  } else if (filterAction === FILTER.ACTION.COLLAPSE) {
+    if (keepNode) return true; // matched, so keep
+    // filter out (remove) and add to `renovedNodes` for later removal of linked edge
+    removedNodes.push(node.id);
+    return false;
+  } else {
+    // collapse?!?!?!
+    return true;
   }
 
   // all_no_op
@@ -535,10 +552,15 @@ function m_EdgeIsFiltered(edge, filters, transparency, filterAction, FILTEREDD3D
     const targetId = (typeof edge.target === 'number') ? edge.target : edge.target.id;
     return e.id === targetId;
   });
-  // 1. if source or target is filtered, then we are filtered too
-  if (source === undefined || target === undefined ||
-    source.filteredTransparency < 1.0 ||
-    target.filteredTransparency < 1.0) {
+
+  // 1. If source or target are missing, then remove the edge
+  if (source === undefined || target === undefined ) return false;
+
+  // 2. If source or target have been removed via collapse, remove the edge
+  if (removedNodes.includes(source.id) || removedNodes.includes(edge.id)) return false;
+  // 3. if source or target is transparent, then we are transparent too
+  if ( source.filteredTransparency < 1.0 ||
+       target.filteredTransparency < 1.0) {
     // regardless of filter definition...
     // ...if filterAction is FILTER
     // always hide edge if it's attached to a filtered node
@@ -549,7 +571,7 @@ function m_EdgeIsFiltered(edge, filters, transparency, filterAction, FILTEREDD3D
     return true;
   }
 
-  // 2. otherwise, look for matches
+  // 4. otherwise, look for matches
   // implicit AND.  ALL filters must return true.
   // edge is filtered out if it fails ANY filter tests
   filters.forEach(filter => {
@@ -568,14 +590,20 @@ function m_EdgeIsFiltered(edge, filters, transparency, filterAction, FILTEREDD3D
     edge.filteredTransparency = EDGE_DEFAULT_TRANSPARENCY; // opaque
     if (keepEdge) return true; // keep in array
     return false; // remove from array
-  } else {
-    // FILTER.ACTION.HIGHLIGHT, so don't filter
+  } else if (filterAction === FILTER.ACTION.HIGHLIGHT) {
     if (!keepEdge) {
       edge.filteredTransparency = transparency; // set the transparency value ... right now it is inefficient to set this at the node / edge level, but that's more flexible
     } else {
       edge.filteredTransparency = EDGE_DEFAULT_TRANSPARENCY; // opaque
     }
     return true; // always keep in array
+  } else if (filterAction === FILTER.ACTION.COLLAPSE) {
+    if (keepEdge) return true; // matched, so keep
+    // else filter out (remove)
+    return false;
+  } else {
+    // keep by default if no filter
+    return true;
   }
 
   // all_no_op

--- a/build/app/view/netcreate/nc-logic.js
+++ b/build/app/view/netcreate/nc-logic.js
@@ -1,5 +1,9 @@
 /*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
 
+  nc-logic
+
+  Net.Create application logic
+
   * EVENTS: D3 Graph Updates
 
     Mark Node/Edge          Nodes in the graph are marked via a stroke around
@@ -1158,7 +1162,7 @@ function m_MarkNodeById(id, color) {
   // to override the properties
   m_SetMatchingNodesByProp({ id }, marked, normal);
 
-    UDATA.SetAppState("NCDATA", NCDATA);
+  UDATA.SetAppState("NCDATA", NCDATA);
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/ Sets the `node.selected` property to `color` so it is hilited on graph

--- a/build/app/view/netcreate/nc-utils.js
+++ b/build/app/view/netcreate/nc-utils.js
@@ -3,7 +3,9 @@
   nc-utils
 
   General purpose utilities for manipulating NCDATA.
-  Used by both nc-logic and importexport-logic.
+  Used by:
+  * nc-logic
+  * filter-logic
 
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
 


### PR DESCRIPTION
This adds a new "Collapse" panel to the "FILTER" feature, addressing #248.

The collapse function will:
1. Keep any matching nodes or edges visible
2. Remove any non-matching nodes or edges
3. Recalculate node sizes and edge weights accounting for the removed nodes and edges.

The functionality matches the Highlight and Filter functions.  Any nodes or edges matched on the Highlight and Filter functions will also match on the Collapse function.  This way you can click back and forth between the three methods to explore the effect of the different functions on the same search.


#### Other fixes:

* Help Text -- I tried modifying the help text to make the differences a little more apparent.  I'm still having a hard time getting my head around how things work...see #263 for a discussion on renaming.
* The help text is now set in the `FilterEnum.js` file, mostly to put all the naming and help in one place.  (The filter summary text is also using the enum).

@jdanish please give this a whirl to see if it meets your goals.



# TO DO
* [x] #267 
* [x] #268 
* [x] #269 
* [x] #270
* [x] Reorder Nodes table columns: Tags, Notes, Provenance, then Updated and Comments?
* [x] Switching between View modes is not updating tables correctly (probably updating from NCDATA rather than filteredDataSet).
* [x] Make filter panel scroll #277 
* [x] Rename Filters to "Fade" and "Remove"

