### PR TITLE
Feature: Focus

### DIFF
--- a/build/app/view/netcreate/NetCreate.jsx
+++ b/build/app/view/netcreate/NetCreate.jsx
@@ -53,6 +53,7 @@ const InfoPanel    = require('./components/InfoPanel');
 const FiltersPanel = require('./components/filter/FiltersPanel');
 const NCLOGIC      = require('./nc-logic'); // require to bootstrap data loading
 const FILTERLOGIC  = require('./filter-logic'); // handles filtering functions
+const FILTER = require('./components/filter/FilterEnums');
 
 /// REACT COMPONENT ///////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -195,7 +196,7 @@ const FILTERLOGIC  = require('./filter-logic'); // handles filtering functions
                       <Button onClick={this.onFilterBtnClick}
                         style={{ width: '90px' }}
                       >
-                        FILTER &gt;
+                        {FILTER.PANEL_LABEL} &gt;
                       </Button>
                       <FiltersPanel />
                     </div>
@@ -208,7 +209,7 @@ const FILTERLOGIC  = require('./filter-logic'); // handles filtering functions
                     <Button
                       onClick={this.onFilterBtnClick}
                       style={{ width: '90px', float: 'right' }}
-                    >&lt; FILTER</Button>
+                    >&lt; {FILTER.PANEL_LABEL}</Button>
                   </div>
               }
             </div>

--- a/build/app/view/netcreate/NetCreate.jsx
+++ b/build/app/view/netcreate/NetCreate.jsx
@@ -190,9 +190,13 @@ const FILTER = require('./components/filter/FilterEnums');
                 // OPEN
                 ? <div id="right" style={{
                     marginTop: '38px', padding: '0 5px', backgroundColor: '#6c757d',
-                    borderTopLeftRadius: '10px', width: 'auto'
+                    borderTopLeftRadius: '10px',
+                    paddingBottom: '25px', // avoid footer
                   }}>
-                    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'end' }}>
+                    <div style={{
+                      display: 'flex', flexDirection: 'column', alignItems: 'end',
+                      height: '100%', overflow: 'hidden'
+                    }}>
                       <Button onClick={this.onFilterBtnClick}
                         style={{ width: '90px' }}
                       >

--- a/build/app/view/netcreate/components/EdgeTable.jsx
+++ b/build/app/view/netcreate/components/EdgeTable.jsx
@@ -199,7 +199,19 @@ class EdgeTable extends UNISYS.Component {
   handleFilterDataUpdate(data) {
     if (data.edges) {
       const filteredEdges = data.edges;
-      this.setState({ filteredEdges }, () => {
+
+      // OLD METHOD: Keep a pure edges object, and apply filtering to them
+      // this.setState({ filteredEdges }, () => {
+      //   const edges = this.sortTable(this.state.sortkey, this.state.edges);
+      //   this.updateEdgeFilterState(edges, filteredEdges);
+      // });
+
+      // NEW METHOD: Just replace pure edges with filtered edges
+      //             This way edges that have been filtered out are also removed from the table
+      this.setState({
+        edges: filteredEdges,
+        filteredEdges
+      }, () => {
         const edges = this.sortTable(this.state.sortkey, this.state.edges);
         this.updateEdgeFilterState(edges, filteredEdges);
       });

--- a/build/app/view/netcreate/components/EdgeTable.jsx
+++ b/build/app/view/netcreate/components/EdgeTable.jsx
@@ -193,7 +193,7 @@ class EdgeTable extends UNISYS.Component {
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /*/ Handle FILTEREDD3DATA updates sent by filters-logic.m_FiltersApply
-      Note that edge.soourceLabel and edge.targetLabe should already be set
+      Note that edge.soourceLabel and edge.targetLabel should already be set
       by filter-logic.
   /*/
   handleFilterDataUpdate(data) {

--- a/build/app/view/netcreate/components/EdgeTable.jsx
+++ b/build/app/view/netcreate/components/EdgeTable.jsx
@@ -137,7 +137,7 @@ class EdgeTable extends UNISYS.Component {
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   displayUpdated(nodeEdge) {
       // Prevent error if `meta` info is not defined yet, or not properly imported
-      if (!nodeEdge.meta) return;
+    if (!nodeEdge.meta) return '';
 
       var d = new Date(nodeEdge.meta.revision > 0 ? nodeEdge.meta.updated : nodeEdge.meta.created);
 

--- a/build/app/view/netcreate/components/EdgeTable.jsx
+++ b/build/app/view/netcreate/components/EdgeTable.jsx
@@ -158,11 +158,21 @@ class EdgeTable extends UNISYS.Component {
   updateEdgeFilterState(edges, filteredEdges) {
     // add highlight/filter status
     if (filteredEdges.length > 0) {
-      edges = edges.map(edge => {
-        const filteredEdge = filteredEdges.find(n => n.id === edge.id);
-        edge.isFiltered = !filteredEdge;
-        return edge;
-      });
+      // If we're transitioning from "HILIGHT/FADE" to "COLLAPSE" or "FOCUS", then we
+      // also need to remove edges that are not in filteredEdges
+      const FDATA = UDATA.AppState("FDATA");
+      if (FDATA.filterAction === FILTER.ACTION.COLLAPSE || FDATA.filterAction === FILTER.ACTION.FOCUS) {
+        edges = edges.filter(edge => {
+          const filteredEdge = filteredEdges.find(n => n.id === edge.id);
+          return edge;
+        });
+      } else {
+        edges = edges.map(edge => {
+          const filteredEdge = filteredEdges.find(n => n.id === edge.id);
+          edge.isFiltered = !filteredEdge;
+          return edge;
+        });
+      }
     }
     this.setState({edges});
   }
@@ -199,22 +209,28 @@ class EdgeTable extends UNISYS.Component {
   handleFilterDataUpdate(data) {
     if (data.edges) {
       const filteredEdges = data.edges;
-
-      // OLD METHOD: Keep a pure edges object, and apply filtering to them
-      // this.setState({ filteredEdges }, () => {
-      //   const edges = this.sortTable(this.state.sortkey, this.state.edges);
-      //   this.updateEdgeFilterState(edges, filteredEdges);
-      // });
-
-      // NEW METHOD: Just replace pure edges with filtered edges
-      //             This way edges that have been filtered out are also removed from the table
-      this.setState({
-        edges: filteredEdges,
-        filteredEdges
-      }, () => {
-        const edges = this.sortTable(this.state.sortkey, this.state.edges);
-        this.updateEdgeFilterState(edges, filteredEdges);
-      });
+      // If we're transitioning from "COLLAPSE" or "FOCUS" to "HILIGHT/FADE", then we
+      // also need to add back in edges that are not in filteredEdges
+      // (because "COLLAPSE" and "FOCUS" removes edges that are not matched)
+      const FDATA = UDATA.AppState("FDATA");
+      if (FDATA.filterAction === FILTER.ACTION.HIGHLIGHT) {
+        const NCDATA = UDATA.AppState("NCDATA");
+        this.setState({
+          edges: NCDATA.edges,
+          filteredEdges
+        }, () => {
+          const edges = this.sortTable(this.state.sortkey, NCDATA.edges);
+          this.updateEdgeFilterState(edges, filteredEdges);
+        });
+      } else {
+        this.setState({
+          edges: filteredEdges,
+          filteredEdges
+        }, () => {
+          const edges = this.sortTable(this.state.sortkey, filteredEdges);
+          this.updateEdgeFilterState(edges, filteredEdges);
+        });
+      }
     }
   }
 

--- a/build/app/view/netcreate/components/EdgeTable.jsx
+++ b/build/app/view/netcreate/components/EdgeTable.jsx
@@ -546,7 +546,7 @@ class EdgeTable extends UNISYS.Component {
                       onClick={()=>this.setSortKey("Updated", FILTER.TYPES.STRING)}
                     >Updated {this.sortSymbol("Updated")}</Button></th>
                 <th  width="10%"hidden={edgeDefs.comments.hidden}><Button size="sm"
-                      onClick={()=>this.setSortKey("comments", edgeDefs.comment.type)}
+                      onClick={()=>this.setSortKey("comments", edgeDefs.comments.type)}
                     >{edgeDefs.comments.displayLabel} {this.sortSymbol("comments")}</Button></th>
               </tr>
             </thead>

--- a/build/app/view/netcreate/components/NodeTable.jsx
+++ b/build/app/view/netcreate/components/NodeTable.jsx
@@ -450,14 +450,14 @@ render() {
                 <Button size="sm"
                   onClick={()=>this.setSortKey("info", nodeDefs.info.type)}
                 >{nodeDefs.info.displayLabel} {this.sortSymbol("info")}</Button></th>
-            <th width="9%"hidden={nodeDefs.provenance.hidden}>
-                <Button size="sm"
-                  onClick={()=>this.setSortKey("provenance", nodeDefs.provenance.type)}
-                >{nodeDefs.provenance.displayLabel} {this.sortSymbol("provenance")}</Button></th>
             <th width="25%" hidden={nodeDefs.notes.hidden}>
                 <Button size="sm"
                   onClick={()=>this.setSortKey("notes", nodeDefs.notes.type)}
                 >{nodeDefs.notes.displayLabel} {this.sortSymbol("notes")}</Button></th>
+            <th width="9%"hidden={nodeDefs.provenance.hidden}>
+                <Button size="sm"
+                  onClick={()=>this.setSortKey("provenance", nodeDefs.provenance.type)}
+                >{nodeDefs.provenance.displayLabel} {this.sortSymbol("provenance")}</Button></th>
             <th  width="10%"hidden={!isLocalHost}><Button size="sm"
                   onClick={()=>this.setSortKey("updated", FILTER.TYPES.STRING)}
                 >Updated {this.sortSymbol("updated")}</Button></th>
@@ -485,12 +485,12 @@ render() {
                 >{node.label}</a></td>
             <td hidden={nodeDefs.type.hidden}>{node.type}</td>
             <td hidden={nodeDefs.info.hidden}>{node.info}</td>
-            <td hidden={nodeDefs.provenance.hidden}
-              style={{ fontSize: '9px' }}
-            >{node.provenance}</td>
             <td hidden={nodeDefs.notes.hidden}>
               {node.notes ? <MarkdownNote text={node.notes} /> : "" }
             </td>
+            <td hidden={nodeDefs.provenance.hidden}
+              style={{ fontSize: '9px' }}
+            >{node.provenance}</td>
             <td hidden={!isLocalHost}
               style={{ fontSize: '9px' }}
             >{this.displayUpdated(node)}</td>

--- a/build/app/view/netcreate/components/NodeTable.jsx
+++ b/build/app/view/netcreate/components/NodeTable.jsx
@@ -175,7 +175,19 @@ class NodeTable extends UNISYS.Component {
   handleFilterDataUpdate(data) {
     if (data.nodes) {
       const filteredNodes = data.nodes;
-      this.setState({ filteredNodes }, () => {
+
+      // OLD METHOD: Keep a pure nodes object, and apply filtering to them
+      // this.setState({ filteredNodes }, () => {
+      //   const nodes = this.sortTable(this.state.sortkey, this.state.nodes);
+      //   this.updateNodeFilterState(nodes, filteredNodes);
+      // });
+
+      // NEW METHOD: Just replace pure nodes with filtered nodes
+      //             This way nodes that have been filtered out are also removed from the table
+      this.setState({
+        nodes: filteredNodes,
+        filteredNodes
+      }, () => {
         const nodes = this.sortTable(this.state.sortkey, this.state.nodes);
         this.updateNodeFilterState(nodes, filteredNodes);
       });

--- a/build/app/view/netcreate/components/NodeTable.jsx
+++ b/build/app/view/netcreate/components/NodeTable.jsx
@@ -129,7 +129,7 @@ class NodeTable extends UNISYS.Component {
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   displayUpdated(nodeEdge) {
       // Prevent error if `meta` info is not defined yet, or not properly imported
-      if (!nodeEdge.meta) return;
+      if (!nodeEdge.meta) return '';
 
       var d = new Date(nodeEdge.meta.revision > 0 ? nodeEdge.meta.updated : nodeEdge.meta.created);
 
@@ -142,7 +142,6 @@ class NodeTable extends UNISYS.Component {
       var tag = <span title={titleString}> {dateTime} </span>;
 
       return tag;
-
     }
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/build/app/view/netcreate/components/filter/FilterEnums.js
+++ b/build/app/view/netcreate/components/filter/FilterEnums.js
@@ -1,5 +1,8 @@
 const FILTER = {};
 
+// Filter Panel Label
+FILTER.PANEL_LABEL = 'VIEWS';
+
 // Determines whether filter action is to highlight/fade or remove (filter) nodes and edges
 FILTER.ACTION = {};
 FILTER.ACTION.HIGHLIGHT = 'HIGHLIGHTING';

--- a/build/app/view/netcreate/components/filter/FilterEnums.js
+++ b/build/app/view/netcreate/components/filter/FilterEnums.js
@@ -2,8 +2,12 @@ const FILTER = {};
 
 // Determines whether filter action is to highlight/fade or remove (filter) nodes and edges
 FILTER.ACTION = {};
-FILTER.ACTION.HIGHLIGHT = 'highlight';
-FILTER.ACTION.FILTER = 'filter';
+FILTER.ACTION.HIGHLIGHT = 'HIGHLIGHTING';
+FILTER.ACTION.FILTER = 'FILTERING';
+FILTER.ACTION.HELP = {};
+FILTER.ACTION.HELP.HIGHLIGHT = 'Show (Highlight) matches, Fade others';
+FILTER.ACTION.HELP.FILTER = 'Shows matches, Hide (Filter) others (keep physics and degrees)';
+FILTER.ACTION.HELP.COLLAPSE = 'Show matches, Remove (collapse) others & recalculate sizes';
 
 // Types of filters definable in template files.
 FILTER.TYPES = {};

--- a/build/app/view/netcreate/components/filter/FilterEnums.js
+++ b/build/app/view/netcreate/components/filter/FilterEnums.js
@@ -8,10 +8,12 @@ FILTER.ACTION = {};
 FILTER.ACTION.HIGHLIGHT = 'HIGHLIGHTING';
 FILTER.ACTION.FILTER = 'FILTERING';
 FILTER.ACTION.COLLAPSE = 'COLLAPSING';
+FILTER.ACTION.FOCUS = 'FOCUSING';
 FILTER.ACTION.HELP = {};
 FILTER.ACTION.HELP.HIGHLIGHT = 'Show (Highlight) matches, Fade others';
 FILTER.ACTION.HELP.FILTER = 'Shows matches, Hide (Filter) others (keep physics and degrees)';
 FILTER.ACTION.HELP.COLLAPSE = 'Show matches, Remove (collapse) others & recalculate sizes';
+FILTER.ACTION.HELP.FOCUS = 'Show only nodes connected to the selected node within range';
 
 // Types of filters definable in template files.
 FILTER.TYPES = {};

--- a/build/app/view/netcreate/components/filter/FilterEnums.js
+++ b/build/app/view/netcreate/components/filter/FilterEnums.js
@@ -5,14 +5,14 @@ FILTER.PANEL_LABEL = 'VIEWS';
 
 // Determines whether filter action is to highlight/fade or remove (filter) nodes and edges
 FILTER.ACTION = {};
-FILTER.ACTION.HIGHLIGHT = 'HIGHLIGHTING';
+FILTER.ACTION.HIGHLIGHT = 'FADE';
 FILTER.ACTION.FILTER = 'FILTERING';
-FILTER.ACTION.COLLAPSE = 'COLLAPSING';
-FILTER.ACTION.FOCUS = 'FOCUSING';
+FILTER.ACTION.COLLAPSE = 'REMOVE';
+FILTER.ACTION.FOCUS = 'FOCUS';
 FILTER.ACTION.HELP = {};
-FILTER.ACTION.HELP.HIGHLIGHT = 'Show (Highlight) matches, Fade others';
+FILTER.ACTION.HELP.HIGHLIGHT = 'Show matches, Fade others';
 FILTER.ACTION.HELP.FILTER = 'Shows matches, Hide (Filter) others (keep physics and degrees)';
-FILTER.ACTION.HELP.COLLAPSE = 'Show matches, Remove (collapse) others & recalculate sizes';
+FILTER.ACTION.HELP.COLLAPSE = 'Show matches, Remove others & recalculate sizes';
 FILTER.ACTION.HELP.FOCUS = 'Show only nodes connected to the selected node within range';
 
 // Types of filters definable in template files.

--- a/build/app/view/netcreate/components/filter/FilterEnums.js
+++ b/build/app/view/netcreate/components/filter/FilterEnums.js
@@ -4,6 +4,7 @@ const FILTER = {};
 FILTER.ACTION = {};
 FILTER.ACTION.HIGHLIGHT = 'HIGHLIGHTING';
 FILTER.ACTION.FILTER = 'FILTERING';
+FILTER.ACTION.COLLAPSE = 'COLLAPSING';
 FILTER.ACTION.HELP = {};
 FILTER.ACTION.HELP.HIGHLIGHT = 'Show (Highlight) matches, Fade others';
 FILTER.ACTION.HELP.FILTER = 'Shows matches, Hide (Filter) others (keep physics and degrees)';

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -45,7 +45,8 @@ class FiltersPanel extends UNISYS.Component {
     this.state = {
       nodes: FDATA.nodes,
       edges: FDATA.edges,
-      filterAction: FILTER.ACTION.HIGHLIGHT
+      filterAction: FILTER.ACTION.HIGHLIGHT,
+      filterActionHelp: FILTER.ACTION.HELP.HIGHLIGHT
     };
     UDATA.OnAppStateChange("FDATA", this.UpdateFilterDefs);
   } // constructor
@@ -60,7 +61,8 @@ class FiltersPanel extends UNISYS.Component {
       return {
         nodes: data.nodes,
         edges: data.edges,
-        filterAction: data.filterAction || state.filterAction
+        filterAction: data.filterAction || state.filterAction,
+        filterActionHelp: data.filterActionHelp || state.filterActionHelp
       }
     });
   }
@@ -70,12 +72,15 @@ class FiltersPanel extends UNISYS.Component {
   }
 
   SelectFilterAction(filterAction) {
-    this.setState({ filterAction });
+    let filterActionHelp;
+    if (filterAction === FILTER.ACTION.HIGHLIGHT) filterActionHelp = FILTER.ACTION.HELP.HIGHLIGHT;
+    if (filterAction === FILTER.ACTION.FILTER) filterActionHelp = FILTER.ACTION.HELP.FILTER;
+    this.setState({ filterAction, filterActionHelp });
     UDATA.LocalCall('FILTERS_UPDATE', { filterAction });
   }
 
   render() {
-    const { filterAction } = this.state;
+    const { filterAction, filterActionHelp } = this.state;
     const defs = [this.state.nodes, this.state.edges];
     return (
       <div className="filterPanel"
@@ -109,10 +114,7 @@ class FiltersPanel extends UNISYS.Component {
           >Filter</Button>
         </ButtonGroup>
         <Label className="small text-muted" style={{ padding: '0.5em 0 0 0.5em', marginBottom: '0' }}>
-          {filterAction === FILTER.ACTION.HIGHLIGHT
-            ? 'Highlight nodes/edges that match criteria. (Fade others)'
-            : 'Filter shows only nodes/edges that match criteria.  (Removes others)'
-          }
+          {filterActionHelp}
         </Label>
         <hr/>
         <div style={{ display: 'flex', flexDirection: 'column', flexGrow: `1`, justifyContent: 'space-evenly' }}>

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -16,8 +16,8 @@
 
 import FILTER from './FilterEnums';
 import FilterGroup from './FilterGroup';
-import React from 'react';
 import FocusFilter from './FocusFilter';
+import React from 'react';
 const ReactStrap = require('reactstrap');
 
 const { Button, ButtonGroup, Input, Label, FormGroup } = ReactStrap;

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -103,6 +103,7 @@ class FiltersPanel extends UNISYS.Component {
               backgroundColor: filterAction === FILTER.ACTION.HIGHLIGHT ? 'transparent' : '#6c757d88'
             }}
           >Highlight</Button>
+          {/* Hide "Filter" panel.  We will probably remove this functionality.
           <Button
             onClick={() => this.SelectFilterAction(FILTER.ACTION.FILTER)}
             active={filterAction === FILTER.ACTION.FILTER}
@@ -112,7 +113,7 @@ class FiltersPanel extends UNISYS.Component {
               color: filterAction === FILTER.ACTION.FILTER ? '#333' : '#fff',
               backgroundColor: filterAction === FILTER.ACTION.FILTER ? 'transparent' : '#6c757d88'
             }}
-          >Filter</Button>
+          >Filter</Button> */}
           <Button
             onClick={() => this.SelectFilterAction(FILTER.ACTION.COLLAPSE)}
             active={filterAction === FILTER.ACTION.COLLAPSE}

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -75,6 +75,7 @@ class FiltersPanel extends UNISYS.Component {
     let filterActionHelp;
     if (filterAction === FILTER.ACTION.HIGHLIGHT) filterActionHelp = FILTER.ACTION.HELP.HIGHLIGHT;
     if (filterAction === FILTER.ACTION.FILTER) filterActionHelp = FILTER.ACTION.HELP.FILTER;
+    if (filterAction === FILTER.ACTION.COLLAPSE) filterActionHelp = FILTER.ACTION.HELP.COLLAPSE;
     this.setState({ filterAction, filterActionHelp });
     UDATA.LocalCall('FILTERS_UPDATE', { filterAction });
   }
@@ -112,6 +113,16 @@ class FiltersPanel extends UNISYS.Component {
               backgroundColor: filterAction === FILTER.ACTION.FILTER ? 'transparent' : '#6c757d88'
             }}
           >Filter</Button>
+          <Button
+            onClick={() => this.SelectFilterAction(FILTER.ACTION.COLLAPSE)}
+            active={filterAction === FILTER.ACTION.COLLAPSE}
+            outline={filterAction === FILTER.ACTION.COLLAPSE}
+            disabled={filterAction === FILTER.ACTION.COLLAPSE}
+            style={{
+              color: filterAction === FILTER.ACTION.COLLAPSE ? '#333' : '#fff',
+              backgroundColor: filterAction === FILTER.ACTION.COLLAPSE ? 'transparent' : '#6c757d88'
+            }}
+          >Collapse</Button>
         </ButtonGroup>
         <Label className="small text-muted" style={{ padding: '0.5em 0 0 0.5em', marginBottom: '0' }}>
           {filterActionHelp}

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -111,8 +111,8 @@ class FiltersPanel extends UNISYS.Component {
     return (
       <div className="filterPanel"
         style={{
-          overflow: 'auto',
-          marginTop: '6px', padding: '5px',
+          overflow: 'hidden',
+          margin: '6px 0', padding: '5px',
           display: 'flex', flexDirection: 'column',
           backgroundColor: '#EEE',
           zIndex: '2000'
@@ -163,11 +163,15 @@ class FiltersPanel extends UNISYS.Component {
         <Label className="small text-muted" style={{ padding: '0.5em 0 0 0.5em', marginBottom: '0' }}>
           {filterActionHelp}
         </Label>
-        <hr/>
-        <div style={{ display: 'flex', flexDirection: 'column', flexGrow: `1`, justifyContent: 'space-evenly' }}>
-          {FilterControlPanel}
+        <div style={{
+          display: 'flex', flexDirection: 'column', flexGrow: `1`,
+          overflowY: 'scroll'
+        }}>
+          <div>
+            {FilterControlPanel}
+          </div>
         </div>
-        <div style={{ display: 'flex', justifyContent: 'space-evenly', padding: '10px' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-evenly', padding: '5px' }}>
           <Button size="sm" onClick={this.OnClearBtnClick} >Clear Filters</Button>
         </div>
       </div>

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -127,7 +127,7 @@ class FiltersPanel extends UNISYS.Component {
               color: filterAction === FILTER.ACTION.HIGHLIGHT ? '#333' : '#fff',
               backgroundColor: filterAction === FILTER.ACTION.HIGHLIGHT ? 'transparent' : '#6c757d88'
             }}
-          >Highlight</Button>
+          >{FILTER.ACTION.HIGHLIGHT}</Button>
           {/* Hide "Filter" panel.  We will probably remove this functionality.
           <Button
             onClick={() => this.SelectFilterAction(FILTER.ACTION.FILTER)}
@@ -148,7 +148,7 @@ class FiltersPanel extends UNISYS.Component {
               color: filterAction === FILTER.ACTION.COLLAPSE ? '#333' : '#fff',
               backgroundColor: filterAction === FILTER.ACTION.COLLAPSE ? 'transparent' : '#6c757d88'
             }}
-          >Collapse</Button>
+          >{FILTER.ACTION.COLLAPSE}</Button>
           <Button
             onClick={() => this.SelectFilterAction(FILTER.ACTION.FOCUS)}
             active={filterAction === FILTER.ACTION.FOCUS}
@@ -158,7 +158,7 @@ class FiltersPanel extends UNISYS.Component {
               color: filterAction === FILTER.ACTION.FOCUS ? '#333' : '#fff',
               backgroundColor: filterAction === FILTER.ACTION.FOCUS ? 'transparent' : '#6c757d88'
             }}
-          >Focus</Button>
+          >{FILTER.ACTION.FOCUS}</Button>
         </ButtonGroup>
         <Label className="small text-muted" style={{ padding: '0.5em 0 0 0.5em', marginBottom: '0' }}>
           {filterActionHelp}

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -17,10 +17,10 @@
 import FILTER from './FilterEnums';
 import FilterGroup from './FilterGroup';
 import React from 'react';
-import StringFilter from './StringFilter';
+import FocusFilter from './FocusFilter';
 const ReactStrap = require('reactstrap');
 
-const { Button, ButtonGroup, Input, Label } = ReactStrap;
+const { Button, ButtonGroup, Input, Label, FormGroup } = ReactStrap;
 
 const UNISYS = require('unisys/client');
 var UDATA  = null;
@@ -46,7 +46,9 @@ class FiltersPanel extends UNISYS.Component {
       nodes: FDATA.nodes,
       edges: FDATA.edges,
       filterAction: FILTER.ACTION.HIGHLIGHT,
-      filterActionHelp: FILTER.ACTION.HELP.HIGHLIGHT
+      filterActionHelp: FILTER.ACTION.HELP.HIGHLIGHT,
+      focusSourceLabel: undefined,
+      focusRange: undefined
     };
     UDATA.OnAppStateChange("FDATA", this.UpdateFilterDefs);
   } // constructor
@@ -62,7 +64,9 @@ class FiltersPanel extends UNISYS.Component {
         nodes: data.nodes,
         edges: data.edges,
         filterAction: data.filterAction || state.filterAction,
-        filterActionHelp: data.filterActionHelp || state.filterActionHelp
+        filterActionHelp: data.filterActionHelp || state.filterActionHelp,
+        focusSourceLabel: data.focus && data.focus.sourceLabel ? `"${data.focus.sourceLabel}"` : "<nothing selected>",
+        focusRange: data.focus && data.focus.range ? data.focus.range : undefined
       }
     });
   }
@@ -76,13 +80,34 @@ class FiltersPanel extends UNISYS.Component {
     if (filterAction === FILTER.ACTION.HIGHLIGHT) filterActionHelp = FILTER.ACTION.HELP.HIGHLIGHT;
     if (filterAction === FILTER.ACTION.FILTER) filterActionHelp = FILTER.ACTION.HELP.FILTER;
     if (filterAction === FILTER.ACTION.COLLAPSE) filterActionHelp = FILTER.ACTION.HELP.COLLAPSE;
+    if (filterAction === FILTER.ACTION.FOCUS) filterActionHelp = FILTER.ACTION.HELP.FOCUS;
     this.setState({ filterAction, filterActionHelp });
     UDATA.LocalCall('FILTERS_UPDATE', { filterAction });
   }
 
   render() {
-    const { filterAction, filterActionHelp } = this.state;
+    const { filterAction, filterActionHelp, focusRange, focusSourceLabel } = this.state;
     const defs = [this.state.nodes, this.state.edges];
+
+    let FilterControlPanel;
+    if (filterAction === FILTER.ACTION.FOCUS) {
+      FilterControlPanel = <FocusFilter
+        filter={{ value: 0 }}
+        focusSourceLabel={focusSourceLabel}
+        focusRange={focusRange}
+    />;
+    } else {
+      FilterControlPanel = defs.map(def => <FilterGroup
+        key={def.label}
+        group={def.group}
+        label={def.label}
+        filters={def.filters}
+        filterAction={filterAction}
+        transparency={def.transparency}
+        onFiltersChange={this.OnFilterChange}
+      />);
+     }
+
     return (
       <div className="filterPanel"
         style={{
@@ -124,21 +149,23 @@ class FiltersPanel extends UNISYS.Component {
               backgroundColor: filterAction === FILTER.ACTION.COLLAPSE ? 'transparent' : '#6c757d88'
             }}
           >Collapse</Button>
+          <Button
+            onClick={() => this.SelectFilterAction(FILTER.ACTION.FOCUS)}
+            active={filterAction === FILTER.ACTION.FOCUS}
+            outline={filterAction === FILTER.ACTION.FOCUS}
+            disabled={filterAction === FILTER.ACTION.FOCUS}
+            style={{
+              color: filterAction === FILTER.ACTION.FOCUS ? '#333' : '#fff',
+              backgroundColor: filterAction === FILTER.ACTION.FOCUS ? 'transparent' : '#6c757d88'
+            }}
+          >Focus</Button>
         </ButtonGroup>
         <Label className="small text-muted" style={{ padding: '0.5em 0 0 0.5em', marginBottom: '0' }}>
           {filterActionHelp}
         </Label>
         <hr/>
         <div style={{ display: 'flex', flexDirection: 'column', flexGrow: `1`, justifyContent: 'space-evenly' }}>
-          {defs.map(def => <FilterGroup
-            key={def.label}
-            group={def.group}
-            label={def.label}
-            filters={def.filters}
-            filterAction={filterAction}
-            transparency={def.transparency}
-            onFiltersChange={this.OnFilterChange}
-          />)}
+          {FilterControlPanel}
         </div>
         <div style={{ display: 'flex', justifyContent: 'space-evenly', padding: '10px' }}>
           <Button size="sm" onClick={this.OnClearBtnClick} >Clear Filters</Button>

--- a/build/app/view/netcreate/components/filter/FocusFilter.jsx
+++ b/build/app/view/netcreate/components/filter/FocusFilter.jsx
@@ -1,0 +1,96 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  FOCUSFILTER
+
+  FocusFilter provides the UI for entering the numeric range value for
+  the focus filter.
+
+  Selection changes directly trigger a UDATA.LocalCall('FILTER_DEFINE',...).
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+
+import React from 'react';
+const ReactStrap = require('reactstrap');
+const { Form, FormGroup, Input, Label } = ReactStrap;
+
+const UNISYS = require('unisys/client');
+var UDATA = null;
+
+
+/// CLASS /////////////////////////////////////////////////////////////////////
+class FocusFilter extends React.Component {
+
+  constructor({
+    focusRange
+  }) {
+    super();
+    this.OnChangeValue = this.OnChangeValue.bind(this);
+    this.TriggerChangeHandler = this.TriggerChangeHandler.bind(this);
+    this.OnSubmit = this.OnSubmit.bind(this);
+
+    this.state = {
+      focusRange: focusRange // Used locally to define result
+    };
+
+    /// Initialize UNISYS DATA LINK for REACT
+    UDATA = UNISYS.NewDataLink(this);
+  }
+
+  OnChangeValue(e) {
+    // The built in <input min="0"> will keep the step buttons from going below 0,
+    // but the user can still input "0".  We can't just use Math.min() because the
+    // user would not be allowed to use backspace to delete the value before
+    // entering a new number.  Replacing invalid numbers with a blank value
+    // feels like a  more natural way of editing.
+    const focusRange = e.target.value < 1 ? "" : e.target.value;
+    this.setState({ focusRange }, this.TriggerChangeHandler);
+  }
+
+  TriggerChangeHandler() {
+    // even though we allow "" in the field, we always define the range to be 1
+    // so that something will show
+    const focusRange = this.state.focusRange < 1 ? 1 : this.state.focusRange;
+    if (UDATA) UDATA.LocalCall('FILTER_DEFINE', {
+      group: "focus",
+      filter: {
+        value: focusRange
+      }
+    }); // set a SINGLE filter
+  }
+
+  OnSubmit(e) {
+    // Prevent "ENTER" from triggering form submission!
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
+  render() {
+    const { focusSourceLabel } = this.props;
+    const { focusRange } = this.state;
+    return (
+      <div className="filter-group" style={{margin:'5px 5px 5px 0',padding:'10px',backgroundColor:'rgba(0,0,0,0)'}}>
+        <Form inline className="filter-item" onSubmit={this.OnSubmit}>
+          {/* FormGroup needs to unset flexFlow or fields will overflow
+              https://getbootstrap.com/docs/4.5/utilities/flex/
+          */}
+          <FormGroup className="flex-nowrap">
+            <Label size="sm" className="small text-muted">Selected Node: {focusSourceLabel}</Label><br/>
+          </FormGroup>
+          <FormGroup className="flex-nowrap">
+            <Label size="sm" className="small text-muted">Range <i>(&gt;0)</i>:&nbsp;</Label>
+            <Input type="number" min="1"
+              style={{ maxWidth: '12em', height: '1.5em', padding: '2px' }} bsSize="sm"
+              onChange={this.OnChangeValue}
+              value={focusRange}
+            />
+          </FormGroup>
+        </Form>
+      </div>
+    );
+  }
+}
+
+/// EXPORT CLASS DEFINITION ///////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+export default FocusFilter;

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -299,11 +299,9 @@ function m_FilterDefine(data) {
   FDATA.filterAction = data.filterAction || FDATA.filterAction; // if 'transparency' then filterAction is not passed, so default to existing
   if (data.group === "nodes") {
 
-    if (data.type === "transparency")
-    {
+    if (data.type === "transparency") {
       FDATA.nodes.transparency = data.transparency;
-    }
-    else{
+    } else {
       let nodeFilters = FDATA.nodes.filters;
       const index = nodeFilters.findIndex(f => f.id === data.filter.id);
       nodeFilters.splice(index, 1, data.filter);
@@ -311,11 +309,9 @@ function m_FilterDefine(data) {
     }
   } else if (data.group === "edges") {
 
-    if (data.type === "transparency")
-    {
+    if (data.type === "transparency") {
       FDATA.edges.transparency = data.transparency;
-    }
-    else{
+    } else {
       let edgeFilters = FDATA.edges.filters;
       const index = edgeFilters.findIndex(f => f.id === data.filter.id);
       edgeFilters.splice(index, 1, data.filter);
@@ -323,8 +319,7 @@ function m_FilterDefine(data) {
     }
   } else if (data.group === "focus") {
     FDATA.focus.range = data.filter.value;
-  }
-  else {
+  } else {
     throw `FILTER_DEFINE called with unknown group: ${data.group}`;
   }
   UDATA.SetAppState("FDATA", FDATA);

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -333,8 +333,7 @@ function m_UpdateFilterSummary() {
   const nodeFilters = FDATA.nodes.filters;
   const edgeFilters = FDATA.edges.filters;
 
-  const typeSummary = FDATA.filterAction === FILTER.ACTION.HIGHLIGHT
-    ? 'HIGHLIGHTING ' : 'FILTERING ';
+  const typeSummary = FDATA.filterAction; // text for filter action is the label, e.g. 'HIGHLIGHT'
   const nodeSummary = m_FiltersToString(FDATA.nodes.filters);
   const edgeSummary = m_FiltersToString(FDATA.edges.filters);
   let summary = '';

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -501,16 +501,15 @@ function m_NodeIsFiltered(node, FDATA) {
   });
 
   // 2. Decide based on filterAction
+  node.isFiltered = false; // always reset if not HIGHLIGHT
+  node.filteredTransparency = NODE_DEFAULT_TRANSPARENCY; // always reset if not HIGHLIGHT
   if (filterAction === FILTER.ACTION.FILTER) {
     // not using highlight, so restore transparency
-    node.filteredTransparency = NODE_DEFAULT_TRANSPARENCY; // opaque, not transparent
     if (keepNode) return true;
     return false; // remove from array
   } else if (filterAction === FILTER.ACTION.HIGHLIGHT) {
     if (!keepNode) {
       node.filteredTransparency = transparency; // set the transparency value ... right now it is inefficient to set this at the node / edge level, but that's more flexible
-    } else {
-      node.filteredTransparency = NODE_DEFAULT_TRANSPARENCY; // opaque
     }
     return true; // don't filter out
   } else if (filterAction === FILTER.ACTION.COLLAPSE) {

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -557,7 +557,7 @@ function m_EdgeIsFiltered(edge, filters, transparency, filterAction, FILTEREDD3D
   if (source === undefined || target === undefined ) return false;
 
   // 2. If source or target have been removed via collapse, remove the edge
-  if (removedNodes.includes(source.id) || removedNodes.includes(edge.id)) return false;
+  if (removedNodes.includes(source.id) || removedNodes.includes(target.id)) return false;
   // 3. if source or target is transparent, then we are transparent too
   if ( source.filteredTransparency < 1.0 ||
        target.filteredTransparency < 1.0) {

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -316,11 +316,16 @@ function m_FiltersApply() {
   m_FiltersApplyToNodes(FDATA, FILTEREDD3DATA);
   m_FiltersApplyToEdges(FDATA, FILTEREDD3DATA);
 
+
+
+  // REVIEW 2023-0530
+  // -- If "Filter/Hide" functionality is going to be kept, this needs to be reworked!
+  //    We SHOULD NOT recalculate sizes in "Filter/Hide" mode, otherwise, the size will change.
+  //
   // Recalculate sizes
-  if ( FDATA.filterAction === FILTER.ACTION.COLLAPSE) {
-    UTILS.RecalculateAllEdgeSizes(FILTEREDD3DATA);
-    UTILS.RecalculateAllNodeDegrees(FILTEREDD3DATA);
-  }
+  // ALWAYS recalculate, e.g. if switching from Collapse to Highlight or clearing data
+  UTILS.RecalculateAllEdgeSizes(FILTEREDD3DATA);
+  UTILS.RecalculateAllNodeDegrees(FILTEREDD3DATA);
 
   // Update FILTEREDD3DATA
   UDATA.SetAppState("FILTEREDD3DATA", FILTEREDD3DATA);

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -81,6 +81,7 @@
 import FILTER from './components/filter/FilterEnums';
 const UNISYS = require("unisys/client");
 const clone = require("rfdc")();
+const UTILS = require("./nc-utils");
 
 /// INITIALIZE MODULE /////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -97,6 +98,7 @@ var FDATA_RESTORE; // pristine FDATA for clearing
 let NODE_DEFAULT_TRANSPARENCY;
 let EDGE_DEFAULT_TRANSPARENCY;
 
+let removedNodes = []; // nodes removed via COLLAPSE filter action
 
 /// CONSTANTS /////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -313,6 +315,13 @@ function m_FiltersApply() {
 
   m_FiltersApplyToNodes(FDATA, FILTEREDD3DATA);
   m_FiltersApplyToEdges(FDATA, FILTEREDD3DATA);
+
+  // Recalculate sizes
+  if ( FDATA.filterAction === FILTER.ACTION.COLLAPSE) {
+    UTILS.RecalculateAllEdgeSizes(FILTEREDD3DATA);
+    UTILS.RecalculateAllNodeDegrees(FILTEREDD3DATA);
+  }
+
   // Update FILTEREDD3DATA
   UDATA.SetAppState("FILTEREDD3DATA", FILTEREDD3DATA);
 
@@ -427,6 +436,7 @@ function m_MatchNumber(operator, filterVal, objVal) {
  * @param {Array} filters
  */
 function m_FiltersApplyToNodes(FDATA, FILTEREDD3DATA) {
+  removedNodes = [];
   const { filterAction } = FDATA;
   const { filters, transparency } = FDATA.nodes;
   FILTEREDD3DATA.nodes = FILTEREDD3DATA.nodes.filter(node => {
@@ -454,14 +464,21 @@ function m_NodeIsFiltered(node, filters, transparency, filterAction) {
     node.filteredTransparency = NODE_DEFAULT_TRANSPARENCY; // opaque, not transparent
     if (keepNode) return true;
     return false; // remove from array
-  } else {
-    // FILTER.ACTION.HIGHLIGHT
+  } else if (filterAction === FILTER.ACTION.HIGHLIGHT) {
     if (!keepNode) {
       node.filteredTransparency = transparency; // set the transparency value ... right now it is inefficient to set this at the node / edge level, but that's more flexible
     } else {
       node.filteredTransparency = NODE_DEFAULT_TRANSPARENCY; // opaque
     }
     return true; // don't filter out
+  } else if (filterAction === FILTER.ACTION.COLLAPSE) {
+    if (keepNode) return true; // matched, so keep
+    // filter out (remove) and add to `renovedNodes` for later removal of linked edge
+    removedNodes.push(node.id);
+    return false;
+  } else {
+    // collapse?!?!?!
+    return true;
   }
 
   // all_no_op
@@ -535,10 +552,15 @@ function m_EdgeIsFiltered(edge, filters, transparency, filterAction, FILTEREDD3D
     const targetId = (typeof edge.target === 'number') ? edge.target : edge.target.id;
     return e.id === targetId;
   });
-  // 1. if source or target is filtered, then we are filtered too
-  if (source === undefined || target === undefined ||
-    source.filteredTransparency < 1.0 ||
-    target.filteredTransparency < 1.0) {
+
+  // 1. If source or target are missing, then remove the edge
+  if (source === undefined || target === undefined ) return false;
+
+  // 2. If source or target have been removed via collapse, remove the edge
+  if (removedNodes.includes(source.id) || removedNodes.includes(edge.id)) return false;
+  // 3. if source or target is transparent, then we are transparent too
+  if ( source.filteredTransparency < 1.0 ||
+       target.filteredTransparency < 1.0) {
     // regardless of filter definition...
     // ...if filterAction is FILTER
     // always hide edge if it's attached to a filtered node
@@ -549,7 +571,7 @@ function m_EdgeIsFiltered(edge, filters, transparency, filterAction, FILTEREDD3D
     return true;
   }
 
-  // 2. otherwise, look for matches
+  // 4. otherwise, look for matches
   // implicit AND.  ALL filters must return true.
   // edge is filtered out if it fails ANY filter tests
   filters.forEach(filter => {
@@ -568,14 +590,20 @@ function m_EdgeIsFiltered(edge, filters, transparency, filterAction, FILTEREDD3D
     edge.filteredTransparency = EDGE_DEFAULT_TRANSPARENCY; // opaque
     if (keepEdge) return true; // keep in array
     return false; // remove from array
-  } else {
-    // FILTER.ACTION.HIGHLIGHT, so don't filter
+  } else if (filterAction === FILTER.ACTION.HIGHLIGHT) {
     if (!keepEdge) {
       edge.filteredTransparency = transparency; // set the transparency value ... right now it is inefficient to set this at the node / edge level, but that's more flexible
     } else {
       edge.filteredTransparency = EDGE_DEFAULT_TRANSPARENCY; // opaque
     }
     return true; // always keep in array
+  } else if (filterAction === FILTER.ACTION.COLLAPSE) {
+    if (keepEdge) return true; // matched, so keep
+    // else filter out (remove)
+    return false;
+  } else {
+    // keep by default if no filter
+    return true;
   }
 
   // all_no_op

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -35,6 +35,11 @@
             label: "Edge Filters",
             filters: [...]
         }
+        focus: {
+          source: undefined,
+          sourceLabel: '',
+          range: 1
+        }
     }
 
 
@@ -98,7 +103,7 @@ var FDATA_RESTORE; // pristine FDATA for clearing
 let NODE_DEFAULT_TRANSPARENCY;
 let EDGE_DEFAULT_TRANSPARENCY;
 
-let removedNodes = []; // nodes removed via COLLAPSE filter action
+let RemovedNodes = []; // nodes removed via COLLAPSE filter action
 
 /// CONSTANTS /////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -140,6 +145,20 @@ MOD.Hook("INITIALIZE", () => {
   UDATA.HandleMessage("FILTERS_UPDATE", data => {
     const FDATA = UDATA.AppState("FDATA");
     FDATA.filterAction = data.filterAction;
+    // if the Focus panel is being selected, grab update the selection so that
+    // the selected node is immediately focused on (otherwise the system ignores
+    // the currently selecte dnode and you have to click on it again)
+    if (data.filterAction === FILTER.ACTION.FOCUS) {
+      const SELECT = UDATA.AppState("SELECTION");
+      const selectedNode = SELECT.nodes ? SELECT.nodes[0] : undefined;
+      if (selectedNode) {
+        FDATA.focus = {
+          source: selectedNode.id,
+          sourceLabel: selectedNode.label,
+          range: FDATA.focus.range
+        };
+      }
+    }
     UDATA.SetAppState("FDATA", FDATA);
   });
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -155,6 +174,18 @@ MOD.Hook("INITIALIZE", () => {
     // this is critical -- graph will not draw if this is
     // not called from nc-logic.LOADASSETS
     m_ImportFilters();
+  });
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /*/ 2023-06 Interim Approach -- eventually should convert to new selection mgr
+      Listen for SELECTION changes for setting Focus
+  /*/
+  UDATA.OnAppStateChange("SELECTION", data => {
+    // Only if Focus is active
+    const FDATA = UDATA.AppState("FDATA");
+    if (FDATA.filterAction === FILTER.ACTION.FOCUS) {
+      m_SetFocus(data);
+    }
   });
 
 }); // end UNISYS_INIT
@@ -185,6 +216,11 @@ function m_ImportFilters() {
       label: "Edge Filters",
       filters: m_ImportPrompts(edgeDefs),
       transparency: 0.03 // Default transparency form for Highlight should be 0.03, not template default which is usu 0.3
+    },
+    focus: {
+      source: undefined, // nothing focused by default
+      sourceLabel: '',
+      range: 1
     }
   };
 
@@ -285,6 +321,8 @@ function m_FilterDefine(data) {
       edgeFilters.splice(index, 1, data.filter);
       FDATA.edges.filters = edgeFilters;
     }
+  } else if (data.group === "focus") {
+    FDATA.focus.range = data.filter.value;
   }
   else {
     throw `FILTER_DEFINE called with unknown group: ${data.group}`;
@@ -315,8 +353,6 @@ function m_FiltersApply() {
 
   m_FiltersApplyToNodes(FDATA, FILTEREDD3DATA);
   m_FiltersApplyToEdges(FDATA, FILTEREDD3DATA);
-
-
 
   // REVIEW 2023-0530
   // -- If "Filter/Hide" functionality is going to be kept, this needs to be reworked!
@@ -441,15 +477,21 @@ function m_MatchNumber(operator, filterVal, objVal) {
  * @param {Array} filters
  */
 function m_FiltersApplyToNodes(FDATA, FILTEREDD3DATA) {
-  removedNodes = [];
-  const { filterAction } = FDATA;
-  const { filters, transparency } = FDATA.nodes;
+  RemovedNodes = [];
+
+  // if current filter is focus, calculate bacon_values
+  if (FDATA.filterAction === FILTER.ACTION.FOCUS) m_FocusPrep(FDATA, FILTEREDD3DATA);
+
   FILTEREDD3DATA.nodes = FILTEREDD3DATA.nodes.filter(node => {
-    return m_NodeIsFiltered(node, filters, transparency, filterAction);
+    return m_NodeIsFiltered(node, FDATA);
   });
 }
 
-function m_NodeIsFiltered(node, filters, transparency, filterAction) {
+function m_NodeIsFiltered(node, FDATA) {
+  const { filterAction } = FDATA;
+  const { filters, transparency } = FDATA.nodes;
+  const { source, range } = FDATA.focus;
+
   // let all_no_op = true;
   let keepNode = true;
 
@@ -478,11 +520,18 @@ function m_NodeIsFiltered(node, filters, transparency, filterAction) {
     return true; // don't filter out
   } else if (filterAction === FILTER.ACTION.COLLAPSE) {
     if (keepNode) return true; // matched, so keep
-    // filter out (remove) and add to `renovedNodes` for later removal of linked edge
-    removedNodes.push(node.id);
+    // filter out (remove) and add to `RemovedNodes` for later removal of linked edge
+    RemovedNodes.push(node.id);
     return false;
+  } else if (filterAction === FILTER.ACTION.FOCUS) {
+    // Remove nodes outside of range
+    if (source !== undefined && (node.bacon_value === undefined || node.bacon_value > range)) {
+      RemovedNodes.push(node.id);
+      return false;
+    }
+    return true;
   } else {
-    // collapse?!?!?!
+    // no filter, keep the node!
     return true;
   }
 
@@ -561,8 +610,8 @@ function m_EdgeIsFiltered(edge, filters, transparency, filterAction, FILTEREDD3D
   // 1. If source or target are missing, then remove the edge
   if (source === undefined || target === undefined ) return false;
 
-  // 2. If source or target have been removed via collapse, remove the edge
-  if (removedNodes.includes(source.id) || removedNodes.includes(target.id)) return false;
+  // 2. If source or target have been removed via collapse or focus, remove the edge
+  if (RemovedNodes.includes(source.id) || RemovedNodes.includes(target.id)) return false;
   // 3. if source or target is transparent, then we are transparent too
   if ( source.filteredTransparency < 1.0 ||
        target.filteredTransparency < 1.0) {
@@ -660,6 +709,106 @@ function m_IsEdgeMatchedByFilter(edge, filter) {
   }
 }
 
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/ FOCUS FILTERS
+/*/
+
+/**
+ * Returns an Map of node ids that are directly connected to the passed `nodeId`
+ * Uses a Map so there are no redundancies.
+ * A more efficient search targeted on looking up nodes
+ * @param {object} puredata Raw/pure data from NCData
+ * @param {array} puredata.nodes
+ * @param {array} puredata.edges where edge.source and edge.target are numeric ids
+ * @param {string} nodeId The source nodeId to start the search from
+ * @returns {map} Map of matching nodeIds {number}
+ */
+function m_FindConnectedNodeIds(puredata, nodeId) {
+  let returnMatches = new Map();
+  puredata.edges.forEach(edge => {
+    if (edge.source === nodeId) returnMatches.set(edge.target, nodeId); // nodeId in returnMatches is not necessary
+    if (edge.target === nodeId) returnMatches.set(edge.source, nodeId);
+  })
+  return returnMatches;
+}
+
+
+/**
+ * Recursively walks down the network starting from the sourceNodes
+ * There can be more than one sourceNodes, e.g. this can set values starting with any number of nodes
+ * Modifies puredata by reference
+ * @param {object} puredata {nodes, edges}
+ * @param {array} sourceNodes {string}
+ * @param {number} range
+ */
+function m_SetBaconValue(bacon_value, max_bacon_value, puredata, sourceNodes) {
+  if (bacon_value > max_bacon_value) return;
+  sourceNodes.forEach(source => {
+    const newNodes = []; // collect new nodes that we need to walk down
+    const connectedNodeIds = m_FindConnectedNodeIds(puredata, source); // map
+    puredata.nodes = puredata.nodes.map(node => {
+      if (node.bacon_value !== undefined) return node; // skip bacon_value if ready set
+
+      if (node.id === source) {
+        node.bacon_value = 0; // the focused node has a value of 0
+      } else if (connectedNodeIds.has(node.id)) {
+        node.bacon_value = bacon_value;
+        newNodes.push(node.id);
+      }
+      return node; // returns node with updated bacon_value
+    });
+
+    // recursive call
+    if (newNodes.length > 0 && bacon_value + 1 <= max_bacon_value) m_SetBaconValue(bacon_value + 1, max_bacon_value, puredata, newNodes);
+  });
+}
+
+/**
+ * Prepares `puredata` (aka FILTEREDD3DATA) for filtering by
+ * seeding node data with "degrees of separation" (aka "bacon_value") from the selected node
+ * Uses FDATA specifications for the focus selection and range
+ * Modifies puredata by reference
+ * This should generally be called right before filtering is applied
+ * @param {*} FDATA
+ * @param {*} puredata
+ */
+function m_FocusPrep(FDATA, puredata) {
+  const { source, range } = FDATA.focus;
+  // first clear bacon_value
+  puredata.nodes = puredata.nodes.map(node => {
+    node.bacon_value = undefined;
+    return node;
+  })
+  if (range < 1) {
+    return; // show all if range=0
+  }
+  // Then set bacon_value
+  // Initiate the crawl starting at 1 with the source node
+  m_SetBaconValue(1, range, puredata, [source]);
+}
+
+/**
+ * Called when SELECTION appState changes, e.g. user has clicked on a node
+ * while in FOCUS View.
+ * @param {object} data
+ * @param {array} data.nodes array of node objects
+ */
+function m_SetFocus(data) {
+  const selectedNode = data.nodes[0];
+  const selectedNodeId = selectedNode ? selectedNode.id : undefined;
+  const selectedNodeLabel = selectedNode ? selectedNode.label : '';
+
+  // Set FDATA
+  const FDATA = UDATA.AppState("FDATA");
+  FDATA.focus = {
+    source: selectedNodeId,
+    sourceLabel: selectedNodeLabel,
+    range: FDATA.focus.range
+  };
+  UDATA.SetAppState("FDATA", FDATA);
+
+  // Actual filtering is done by m_FiltersApply call after FDATA change
+}
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 

--- a/build/app/view/netcreate/nc-logic.js
+++ b/build/app/view/netcreate/nc-logic.js
@@ -1,5 +1,9 @@
 /*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
 
+  nc-logic
+
+  Net.Create application logic
+
   * EVENTS: D3 Graph Updates
 
     Mark Node/Edge          Nodes in the graph are marked via a stroke around
@@ -1158,7 +1162,7 @@ function m_MarkNodeById(id, color) {
   // to override the properties
   m_SetMatchingNodesByProp({ id }, marked, normal);
 
-    UDATA.SetAppState("NCDATA", NCDATA);
+  UDATA.SetAppState("NCDATA", NCDATA);
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/ Sets the `node.selected` property to `color` so it is hilited on graph

--- a/build/app/view/netcreate/nc-utils.js
+++ b/build/app/view/netcreate/nc-utils.js
@@ -3,7 +3,9 @@
   nc-utils
 
   General purpose utilities for manipulating NCDATA.
-  Used by both nc-logic and importexport-logic.
+  Used by:
+  * nc-logic
+  * filter-logic
 
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
 


### PR DESCRIPTION
NOTE: Merge #264 First!

This is a rough first pass at the focus feature.


It made most sense as another temporary "View" modification tied to Filters, so I added it to the panel formerly known as "Filters" but is now called "Views".

# To Test
1. Quit and restart the server.
2. Select a node
3. Click on "Views" panel
4. Click on the "Focus" tab
5. The graph should show your selected node and one degree of separation from that node
6. Use the stepper buttons to move the range up and down.
7. You should be able to increase it to any number
8. You should not be able to able to decrease it below 1
9. You should be able to use backspace to delete the range value and type in a new value
10. If you type in a 0 or negative value, the input field will remain blank
11. Try different range values to make sure the selection range is correct.
12. Open the Nodes Table => The nodes listed in the table should match the visible nodes, any nodes not graph should be removed.
13. Open the Edges Table => The edges should match
14. Clicking "Clear Filters" should restore all the nodes

There may very well be some algorithm issues with the way I'm crawling the network, so please verify that it does what you expect.
There may also be some weird interim states if you're going back and forth between the tables and the filters.


I've also attached a sample project for testing.  Just unzip and put it in `netcreate-2023/build/runtime`
[focus.zip](https://github.com/netcreateorg/netcreate-2018/files/11630271/focus.zip)
