### PR TITLE
Feature: Set Filter Labels in Template

### DIFF
--- a/build/app/system/datastore.js
+++ b/build/app/system/datastore.js
@@ -269,7 +269,7 @@ DSTOR.SaveTemplateFile = template => {
 };
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/ API: Get Template File Path.
-    Called by template-logic when downloading template file.
+    Called by templateEditor-logic when downloading template file.
 /*/
 DSTOR.GetTemplateTOMLFileName = () => {
   return UDATA.Call("SRV_GET_TEMPLATETOML_FILENAME");

--- a/build/app/unisys/server-database.js
+++ b/build/app/unisys/server-database.js
@@ -157,6 +157,7 @@ DB.InitializeDatabase = function (options = {}) {
     m_db.saveDatabase();
 
     await m_LoadTemplate();
+    m_MigrateTemplate();
     m_ValidateTemplate();
   } // end f_DatabaseInitialize
 
@@ -392,6 +393,24 @@ async function m_LoadTemplate() {
     }
   }
 }
+
+/// REVIEW: Should this be moved to a separate server-template module?
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/ Migrate Template File
+    Updates older templates to the current template-schema specification.
+    Any changes to template-schema should be reflected here.
+/*/
+function m_MigrateTemplate() {
+  // 2023-0602 Filter Labels
+  // See branch `template-filter-labels`, and fb28fa68ee42deffc778c1be013acea7dae85258
+  if (TEMPLATE.filterFade === undefined) TEMPLATE.filterFade = FILTER.ACTION.FADE;
+  if (TEMPLATE.filterReduce === undefined) TEMPLATE.filterReduce = FILTER.ACTION.REDUCE;
+  if (TEMPLATE.filterFocus === undefined) TEMPLATE.filterFocus = FILTER.ACTION.FOCUS;
+  if (TEMPLATE.filterFadeHelp === undefined) TEMPLATE.filterFadeHelp = FILTER.ACTION.HELP.FADE;
+  if (TEMPLATE.filterReduceHelp === undefined) TEMPLATE.filterReduceHelp = FILTER.ACTION.HELP.REDUCE;
+  if (TEMPLATE.filterFocusHelp === undefined) TEMPLATE.filterFocusHelp = FILTER.ACTION.HELP.FOCUS;
+}
+
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/ Validate Template File
 /*/

--- a/build/app/view/netcreate/components/EdgeTable.jsx
+++ b/build/app/view/netcreate/components/EdgeTable.jsx
@@ -161,7 +161,7 @@ class EdgeTable extends UNISYS.Component {
       // If we're transitioning from "HILIGHT/FADE" to "COLLAPSE" or "FOCUS", then we
       // also need to remove edges that are not in filteredEdges
       const FDATA = UDATA.AppState("FDATA");
-      if (FDATA.filterAction === FILTER.ACTION.COLLAPSE || FDATA.filterAction === FILTER.ACTION.FOCUS) {
+      if (FDATA.filterAction === FILTER.ACTION.REDUCE|| FDATA.filterAction === FILTER.ACTION.FOCUS) {
         edges = edges.filter(edge => {
           const filteredEdge = filteredEdges.find(n => n.id === edge.id);
           return edge;
@@ -213,7 +213,7 @@ class EdgeTable extends UNISYS.Component {
       // also need to add back in edges that are not in filteredEdges
       // (because "COLLAPSE" and "FOCUS" removes edges that are not matched)
       const FDATA = UDATA.AppState("FDATA");
-      if (FDATA.filterAction === FILTER.ACTION.HIGHLIGHT) {
+      if (FDATA.filterAction === FILTER.ACTION.FADE) {
         const NCDATA = UDATA.AppState("NCDATA");
         this.setState({
           edges: NCDATA.edges,

--- a/build/app/view/netcreate/components/NodeTable.jsx
+++ b/build/app/view/netcreate/components/NodeTable.jsx
@@ -149,11 +149,10 @@ class NodeTable extends UNISYS.Component {
   updateNodeFilterState(nodes, filteredNodes) {
     // set filter status
     if (filteredNodes.length > 0) {
-
       // If we're transitioning from "HILIGHT/FADE" to "COLLAPSE" or "FOCUS", then we
       // also need to remove nodes that are not in filteredNodes
       const FDATA = UDATA.AppState("FDATA");
-      if (FDATA.filterAction === FILTER.ACTION.COLLAPSE || FDATA.filterAction === FILTER.ACTION.FOCUS) {
+      if (FDATA.filterAction === FILTER.ACTION.REDUCE|| FDATA.filterAction === FILTER.ACTION.FOCUS) {
         nodes = nodes.filter(node => {
           const filteredNode = filteredNodes.find(n => n.id === node.id);
           return filteredNode; // keep if it's in the list of filtered nodes
@@ -191,7 +190,7 @@ class NodeTable extends UNISYS.Component {
       // also need to add back in nodes that are not in filteredNodes
       // (because "COLLAPSE" and "FOCUS" removes nodes that are not matched)
       const FDATA = UDATA.AppState("FDATA");
-      if (FDATA.filterAction === FILTER.ACTION.HIGHLIGHT) {
+      if (FDATA.filterAction === FILTER.ACTION.FADE) {
         const NCDATA = UDATA.AppState("NCDATA");
         this.setState({
           nodes: NCDATA.nodes,

--- a/build/app/view/netcreate/components/Template.jsx
+++ b/build/app/view/netcreate/components/Template.jsx
@@ -39,7 +39,7 @@ const { Button } = ReactStrap;
 import { JSONEditor } from '@json-editor/json-editor';
 const UNISYS = require('unisys/client');
 const { EDITORTYPE } = require("system/util/enum");
-const TEMPLATE_LOGIC = require("../template-logic");
+const TEMPLATE_LOGIC = require("../templateEditor-logic");
 const SCHEMA = require("../template-schema");
 
 /// CONSTANTS /////////////////////////////////////////////////////////////////

--- a/build/app/view/netcreate/components/filter/FilterEnums.js
+++ b/build/app/view/netcreate/components/filter/FilterEnums.js
@@ -4,15 +4,16 @@ const FILTER = {};
 FILTER.PANEL_LABEL = 'VIEWS';
 
 // Determines whether filter action is to highlight/fade or remove (filter) nodes and edges
+// These labels are used as default values if an older version template has not defined them
 FILTER.ACTION = {};
 FILTER.ACTION.FADE = 'FADE';
-FILTER.ACTION.FILTER = 'FILTERING';
+FILTER.ACTION.FILTER = 'FILTERING'; // FIX: Remove this after we decide to remove FILTER/HIDE
 FILTER.ACTION.REDUCE= 'REMOVE';
 FILTER.ACTION.FOCUS = 'FOCUS';
 FILTER.ACTION.HELP = {};
-FILTER.ACTION.HELP.HIGHLIGHT = 'Show matches, Fade others';
-FILTER.ACTION.HELP.FILTER = 'Shows matches, Hide (Filter) others (keep physics and degrees)';
-FILTER.ACTION.HELP.COLLAPSE = 'Show matches, Remove others & recalculate sizes';
+FILTER.ACTION.HELP.FADE = 'Show matches, Fade others';
+FILTER.ACTION.HELP.FILTER = 'Shows matches, Hide (Filter) others (keep physics and degrees)'; // FIX: Remove this after we decide to remove FILTER/HIDE
+FILTER.ACTION.HELP.REDUCE = 'Show matches, Remove others & recalculate sizes';
 FILTER.ACTION.HELP.FOCUS = 'Show only nodes connected to the selected node within range';
 
 // Types of filters definable in template files.

--- a/build/app/view/netcreate/components/filter/FilterEnums.js
+++ b/build/app/view/netcreate/components/filter/FilterEnums.js
@@ -5,9 +5,9 @@ FILTER.PANEL_LABEL = 'VIEWS';
 
 // Determines whether filter action is to highlight/fade or remove (filter) nodes and edges
 FILTER.ACTION = {};
-FILTER.ACTION.HIGHLIGHT = 'FADE';
+FILTER.ACTION.FADE = 'FADE';
 FILTER.ACTION.FILTER = 'FILTERING';
-FILTER.ACTION.COLLAPSE = 'REMOVE';
+FILTER.ACTION.REDUCE= 'REMOVE';
 FILTER.ACTION.FOCUS = 'FOCUS';
 FILTER.ACTION.HELP = {};
 FILTER.ACTION.HELP.HIGHLIGHT = 'Show matches, Fade others';

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -31,6 +31,7 @@ class FiltersPanel extends UNISYS.Component {
     super();
 
     this.UpdateFilterDefs = this.UpdateFilterDefs.bind(this);
+    this.LookupFilterHelp = this.LookupFilterHelp.bind(this);
     this.OnClearBtnClick = this.OnClearBtnClick.bind(this);
     this.SelectFilterAction = this.SelectFilterAction.bind(this);
 
@@ -46,7 +47,6 @@ class FiltersPanel extends UNISYS.Component {
       nodes: FDATA.nodes,
       edges: FDATA.edges,
       filterAction: FILTER.ACTION.FADE,
-      filterActionHelp: FILTER.ACTION.HELP.HIGHLIGHT,
       focusSourceLabel: undefined,
       focusRange: undefined
     };
@@ -71,23 +71,27 @@ class FiltersPanel extends UNISYS.Component {
     });
   }
 
+  LookupFilterHelp(filterAction) {
+    const TEMPLATE = UDATA.AppState("TEMPLATE");
+    if (filterAction === FILTER.ACTION.FADE) return TEMPLATE.filterFadeHelp;
+    if (filterAction === FILTER.ACTION.FILTER) return FILTER.ACTION.HELP.FILTER; // FIX: Remove this once we decide we don't want to support Filter/hide
+    if (filterAction === FILTER.ACTION.REDUCE) return TEMPLATE.filterReduceHelp;
+    if (filterAction === FILTER.ACTION.FOCUS) return TEMPLATE.filterFocusHelp;
+    return "Help not found";
+  }
+
   OnClearBtnClick() {
     UDATA.LocalCall('FILTER_CLEAR');
   }
 
   SelectFilterAction(filterAction) {
-    let filterActionHelp;
     const TEMPLATE = UDATA.AppState("TEMPLATE");
-    if (filterAction === FILTER.ACTION.FADE) filterActionHelp = TEMPLATE.filterFadeHelp ? TEMPLATE.filterFadeHelp : FILTER.ACTION.HELP.FADE;
-    if (filterAction === FILTER.ACTION.FILTER) filterActionHelp = FILTER.ACTION.HELP.FILTER;
-    if (filterAction === FILTER.ACTION.COLLAPSE) filterActionHelp = TEMPLATE.filterReduceHelp ? TEMPLATE.filterReduceHelp : FILTER.ACTION.HELP.REDUCE;
-    if (filterAction === FILTER.ACTION.FOCUS) filterActionHelp = TEMPLATE.filterFocusHelp ? TEMPLATE.filterFocusHelp : FILTER.ACTION.HELP.FOCUS;
-    this.setState({ filterAction, filterActionHelp });
+    this.setState({ filterAction });
     UDATA.LocalCall('FILTERS_UPDATE', { filterAction });
   }
 
   render() {
-    const { filterAction, filterActionHelp, focusRange, focusSourceLabel } = this.state;
+    const { filterAction, focusRange, focusSourceLabel } = this.state;
     const defs = [this.state.nodes, this.state.edges];
 
     // Can we assume TEMPLATE is already loaded by the time we render?
@@ -96,6 +100,7 @@ class FiltersPanel extends UNISYS.Component {
     const labelFade = TEMPLATE.filterFade ? TEMPLATE.filterFade.default : FILTER.ACTION.FADE;
     const labelReduce = TEMPLATE.filterReduce ? TEMPLATE.filterReduce.default : FILTER.ACTION.REDUCE;
     const labelFocus = TEMPLATE.filterFocus ? TEMPLATE.filterFocus.default : FILTER.ACTION.FOCUS;
+    const filterActionHelp = this.LookupFilterHelp(filterAction);
 
     let FilterControlPanel;
     if (filterAction === FILTER.ACTION.FOCUS) {

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -148,10 +148,10 @@ class FiltersPanel extends UNISYS.Component {
             }}
           >Filter</Button> */}
           <Button
-            onClick={() => this.SelectFilterAction(FILTER.ACTION.COLLAPSE)}
-            active={filterAction === FILTER.ACTION.COLLAPSE}
-            outline={filterAction === FILTER.ACTION.COLLAPSE}
-            disabled={filterAction === FILTER.ACTION.COLLAPSE}
+            onClick={() => this.SelectFilterAction(FILTER.ACTION.REDUCE)}
+            active={filterAction === FILTER.ACTION.REDUCE}
+            outline={filterAction === FILTER.ACTION.REDUCE}
+            disabled={filterAction === FILTER.ACTION.REDUCE}
             style={{
               color: filterAction === FILTER.ACTION.REDUCE? '#333' : '#fff',
               backgroundColor: filterAction === FILTER.ACTION.REDUCE? 'transparent' : '#6c757d88'

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -97,9 +97,10 @@ class FiltersPanel extends UNISYS.Component {
     // Can we assume TEMPLATE is already loaded by the time we render?
     const TEMPLATE = UDATA.AppState("TEMPLATE");
 
-    const labelFade = TEMPLATE.filterFade ? TEMPLATE.filterFade.default : FILTER.ACTION.FADE;
-    const labelReduce = TEMPLATE.filterReduce ? TEMPLATE.filterReduce.default : FILTER.ACTION.REDUCE;
-    const labelFocus = TEMPLATE.filterFocus ? TEMPLATE.filterFocus.default : FILTER.ACTION.FOCUS;
+    const labelFade = TEMPLATE.filterFade;
+    const labelReduce = TEMPLATE.filterReduce;
+    const labelFocus = TEMPLATE.filterFocus;
+
     const filterActionHelp = this.LookupFilterHelp(filterAction);
 
     let FilterControlPanel;

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -45,7 +45,7 @@ class FiltersPanel extends UNISYS.Component {
     this.state = {
       nodes: FDATA.nodes,
       edges: FDATA.edges,
-      filterAction: FILTER.ACTION.HIGHLIGHT,
+      filterAction: FILTER.ACTION.FADE,
       filterActionHelp: FILTER.ACTION.HELP.HIGHLIGHT,
       focusSourceLabel: undefined,
       focusRange: undefined
@@ -78,7 +78,7 @@ class FiltersPanel extends UNISYS.Component {
   SelectFilterAction(filterAction) {
     let filterActionHelp;
     const TEMPLATE = UDATA.AppState("TEMPLATE");
-    if (filterAction === FILTER.ACTION.HIGHLIGHT) filterActionHelp = TEMPLATE.filterFadeHelp ? TEMPLATE.filterFadeHelp : FILTER.ACTION.HELP.FADE;
+    if (filterAction === FILTER.ACTION.FADE) filterActionHelp = TEMPLATE.filterFadeHelp ? TEMPLATE.filterFadeHelp : FILTER.ACTION.HELP.FADE;
     if (filterAction === FILTER.ACTION.FILTER) filterActionHelp = FILTER.ACTION.HELP.FILTER;
     if (filterAction === FILTER.ACTION.COLLAPSE) filterActionHelp = TEMPLATE.filterReduceHelp ? TEMPLATE.filterReduceHelp : FILTER.ACTION.HELP.REDUCE;
     if (filterAction === FILTER.ACTION.FOCUS) filterActionHelp = TEMPLATE.filterFocusHelp ? TEMPLATE.filterFocusHelp : FILTER.ACTION.HELP.FOCUS;
@@ -127,13 +127,13 @@ class FiltersPanel extends UNISYS.Component {
         }}>
         <ButtonGroup>
           <Button
-            onClick={() => this.SelectFilterAction(FILTER.ACTION.HIGHLIGHT)}
-            active={filterAction === FILTER.ACTION.HIGHLIGHT}
-            outline={filterAction === FILTER.ACTION.HIGHLIGHT}
-            disabled={filterAction === FILTER.ACTION.HIGHLIGHT}
+            onClick={() => this.SelectFilterAction(FILTER.ACTION.FADE)}
+            active={filterAction === FILTER.ACTION.FADE}
+            outline={filterAction === FILTER.ACTION.FADE}
+            disabled={filterAction === FILTER.ACTION.FADE}
             style={{
-              color: filterAction === FILTER.ACTION.HIGHLIGHT ? '#333' : '#fff',
-              backgroundColor: filterAction === FILTER.ACTION.HIGHLIGHT ? 'transparent' : '#6c757d88'
+              color: filterAction === FILTER.ACTION.FADE ? '#333' : '#fff',
+              backgroundColor: filterAction === FILTER.ACTION.FADE ? 'transparent' : '#6c757d88'
             }}
           >{labelFade}</Button>
           {/* Hide "Filter" panel.  We will probably remove this functionality.
@@ -153,8 +153,8 @@ class FiltersPanel extends UNISYS.Component {
             outline={filterAction === FILTER.ACTION.COLLAPSE}
             disabled={filterAction === FILTER.ACTION.COLLAPSE}
             style={{
-              color: filterAction === FILTER.ACTION.COLLAPSE ? '#333' : '#fff',
-              backgroundColor: filterAction === FILTER.ACTION.COLLAPSE ? 'transparent' : '#6c757d88'
+              color: filterAction === FILTER.ACTION.REDUCE? '#333' : '#fff',
+              backgroundColor: filterAction === FILTER.ACTION.REDUCE? 'transparent' : '#6c757d88'
             }}
           >{labelReduce}</Button>
           <Button

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -77,10 +77,11 @@ class FiltersPanel extends UNISYS.Component {
 
   SelectFilterAction(filterAction) {
     let filterActionHelp;
-    if (filterAction === FILTER.ACTION.HIGHLIGHT) filterActionHelp = FILTER.ACTION.HELP.HIGHLIGHT;
+    const TEMPLATE = UDATA.AppState("TEMPLATE");
+    if (filterAction === FILTER.ACTION.HIGHLIGHT) filterActionHelp = TEMPLATE.filterFadeHelp ? TEMPLATE.filterFadeHelp : FILTER.ACTION.HELP.FADE;
     if (filterAction === FILTER.ACTION.FILTER) filterActionHelp = FILTER.ACTION.HELP.FILTER;
-    if (filterAction === FILTER.ACTION.COLLAPSE) filterActionHelp = FILTER.ACTION.HELP.COLLAPSE;
-    if (filterAction === FILTER.ACTION.FOCUS) filterActionHelp = FILTER.ACTION.HELP.FOCUS;
+    if (filterAction === FILTER.ACTION.COLLAPSE) filterActionHelp = TEMPLATE.filterReduceHelp ? TEMPLATE.filterReduceHelp : FILTER.ACTION.HELP.REDUCE;
+    if (filterAction === FILTER.ACTION.FOCUS) filterActionHelp = TEMPLATE.filterFocusHelp ? TEMPLATE.filterFocusHelp : FILTER.ACTION.HELP.FOCUS;
     this.setState({ filterAction, filterActionHelp });
     UDATA.LocalCall('FILTERS_UPDATE', { filterAction });
   }
@@ -88,6 +89,13 @@ class FiltersPanel extends UNISYS.Component {
   render() {
     const { filterAction, filterActionHelp, focusRange, focusSourceLabel } = this.state;
     const defs = [this.state.nodes, this.state.edges];
+
+    // Can we assume TEMPLATE is already loaded by the time we render?
+    const TEMPLATE = UDATA.AppState("TEMPLATE");
+
+    const labelFade = TEMPLATE.filterFade ? TEMPLATE.filterFade.default : FILTER.ACTION.FADE;
+    const labelReduce = TEMPLATE.filterReduce ? TEMPLATE.filterReduce.default : FILTER.ACTION.REDUCE;
+    const labelFocus = TEMPLATE.filterFocus ? TEMPLATE.filterFocus.default : FILTER.ACTION.FOCUS;
 
     let FilterControlPanel;
     if (filterAction === FILTER.ACTION.FOCUS) {
@@ -127,7 +135,7 @@ class FiltersPanel extends UNISYS.Component {
               color: filterAction === FILTER.ACTION.HIGHLIGHT ? '#333' : '#fff',
               backgroundColor: filterAction === FILTER.ACTION.HIGHLIGHT ? 'transparent' : '#6c757d88'
             }}
-          >{FILTER.ACTION.HIGHLIGHT}</Button>
+          >{labelFade}</Button>
           {/* Hide "Filter" panel.  We will probably remove this functionality.
           <Button
             onClick={() => this.SelectFilterAction(FILTER.ACTION.FILTER)}
@@ -148,7 +156,7 @@ class FiltersPanel extends UNISYS.Component {
               color: filterAction === FILTER.ACTION.COLLAPSE ? '#333' : '#fff',
               backgroundColor: filterAction === FILTER.ACTION.COLLAPSE ? 'transparent' : '#6c757d88'
             }}
-          >{FILTER.ACTION.COLLAPSE}</Button>
+          >{labelReduce}</Button>
           <Button
             onClick={() => this.SelectFilterAction(FILTER.ACTION.FOCUS)}
             active={filterAction === FILTER.ACTION.FOCUS}
@@ -158,7 +166,7 @@ class FiltersPanel extends UNISYS.Component {
               color: filterAction === FILTER.ACTION.FOCUS ? '#333' : '#fff',
               backgroundColor: filterAction === FILTER.ACTION.FOCUS ? 'transparent' : '#6c757d88'
             }}
-          >{FILTER.ACTION.FOCUS}</Button>
+          >{labelFocus}</Button>
         </ButtonGroup>
         <Label className="small text-muted" style={{ padding: '0.5em 0 0 0.5em', marginBottom: '0' }}>
           {filterActionHelp}

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -512,7 +512,7 @@ function m_NodeIsFiltered(node, FDATA) {
       node.filteredTransparency = transparency; // set the transparency value ... right now it is inefficient to set this at the node / edge level, but that's more flexible
     }
     return true; // don't filter out
-  } else if (filterAction === FILTER.ACTION.COLLAPSE) {
+  } else if (filterAction === FILTER.ACTION.REDUCE) {
     if (keepNode) return true; // matched, so keep
     // filter out (remove) and add to `RemovedNodes` for later removal of linked edge
     RemovedNodes.push(node.id);
@@ -645,7 +645,7 @@ function m_EdgeIsFiltered(edge, filters, transparency, filterAction, FILTEREDD3D
       edge.filteredTransparency = EDGE_DEFAULT_TRANSPARENCY; // opaque
     }
     return true; // always keep in array
-  } else if (filterAction === FILTER.ACTION.COLLAPSE) {
+  } else if (filterAction === FILTER.ACTION.REDUCE) {
     if (keepEdge) return true; // matched, so keep
     // else filter out (remove)
     return false;

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -507,7 +507,7 @@ function m_NodeIsFiltered(node, FDATA) {
     // not using highlight, so restore transparency
     if (keepNode) return true;
     return false; // remove from array
-  } else if (filterAction === FILTER.ACTION.HIGHLIGHT) {
+  } else if (filterAction === FILTER.ACTION.FADE) {
     if (!keepNode) {
       node.filteredTransparency = transparency; // set the transparency value ... right now it is inefficient to set this at the node / edge level, but that's more flexible
     }
@@ -638,7 +638,7 @@ function m_EdgeIsFiltered(edge, filters, transparency, filterAction, FILTEREDD3D
     edge.filteredTransparency = EDGE_DEFAULT_TRANSPARENCY; // opaque
     if (keepEdge) return true; // keep in array
     return false; // remove from array
-  } else if (filterAction === FILTER.ACTION.HIGHLIGHT) {
+  } else if (filterAction === FILTER.ACTION.FADE) {
     if (!keepEdge) {
       edge.filteredTransparency = transparency; // set the transparency value ... right now it is inefficient to set this at the node / edge level, but that's more flexible
     } else {

--- a/build/app/view/netcreate/nc-logic.js
+++ b/build/app/view/netcreate/nc-logic.js
@@ -265,7 +265,6 @@ MOD.Hook("LOADASSETS", () => {
 // eslint-disable-next-line complexity
 MOD.Hook("CONFIGURE", () => {
   // Process Node, NodeColorMap and Edge options
-  m_ValidateTemplate();
   m_UpdateColorMap();
 }); // end CONFIGURE HOOK
 
@@ -871,61 +870,6 @@ MOD.SetAllObjs = m_SetAllObjs; // Expose for filter-logic.js
 /// NODE HELPERS //////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-/*/ Validate Template File
-/*/
-// eslint-disable-next-line complexity
-function m_ValidateTemplate() {
-  try {
-    // nodeDefs
-    let nodeDefs = TEMPLATE.nodeDefs;
-    if (nodeDefs === undefined) {
-      throw "Missing `nodeDefs` nodeDefs=" + nodeDefs;
-    }
-    if (nodeDefs.label === undefined) throw "Missing `nodeDefs.label` label=" + nodeDefs.label;
-    if (nodeDefs.type === undefined) throw "Missing `nodeDefs.type` type= " + nodeDefs.type;
-    if (
-      nodeDefs.type.options === undefined ||
-      !Array.isArray(nodeDefs.type.options)
-    ) {
-      throw "Missing or bad `nodeDefs.type.options` options=" +
-        nodeDefs.type.options;
-    }
-    if (nodeDefs.notes === undefined) throw "Missing `nodeDefs.notes` notes=" + nodeDefs.notes;
-    if (nodeDefs.info === undefined) throw "Missing `nodeDefs.info` info=" + nodeDefs.info;
-    // Version 2.x Fields
-    if (nodeDefs.provenance === undefined) throw "Missing `nodeDefs.provenance` provenance=" + nodeDefs.provenance;
-    if (nodeDefs.comments === undefined) throw "Missing `nodeDefs.comments` comments=" + nodeDefs.comments;
-
-    // edgeDefs
-    let edgeDefs = TEMPLATE.edgeDefs;
-    if (edgeDefs === undefined) throw "Missing `edgeDefs` edgeDefs=" + edgeDefs;
-    if (edgeDefs.source === undefined) throw "Missing `edgeDefs.source` source=" + edgeDefs.source;
-    if (edgeDefs.type === undefined) throw "Missing `edgeDefs.type` type= " + edgeDefs.type;
-    if (
-      edgeDefs.type.options === undefined ||
-      !Array.isArray(edgeDefs.type.options)
-    ) {
-      throw "Missing or bad `edgeDefs.type.options` options=" +
-        edgeDefs.type.options;
-    }
-    if (edgeDefs.target === undefined) throw "Missing `edgeDefs.target` label=" + edgeDefs.target;
-    if (edgeDefs.notes === undefined) throw "Missing `edgeDefs.notes` notes=" + edgeDefs.notes;
-    if (edgeDefs.info === undefined) throw "Missing `edgeDefs.info` info=" + edgeDefs.info;
-    // Version 2.x Fields
-    if (edgeDefs.provenance === undefined) throw "Missing `edgeDefs.provenance` provenance=" + edgeDefs.provenance;
-    if (edgeDefs.comments === undefined) throw "Missing `edgeDefs.comments` comments=" + edgeDefs.comments;
-    // -- End 2.x
-    if (edgeDefs.citation === undefined) throw "Missing `edgeDefs.citation` info=" + edgeDefs.citation;
-    if (edgeDefs.category === undefined) throw "Missing `edgeDefs.category` info=" + edgeDefs.category;
-  } catch (error) {
-    console.error(
-      PR + "Error loading template `",
-      TEMPLATE_URL,
-      "`::::",
-      error
-    );
-  }
-}
 
 /*/ Update ColorMap
 /*/

--- a/build/app/view/netcreate/nc-logic.js
+++ b/build/app/view/netcreate/nc-logic.js
@@ -572,7 +572,7 @@ MOD.Hook("INITIALIZE", () => {
     // FIXME: Need to also trigger resize!
   });
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - inside hook
-  /*/ NODE_TYPES_UPDATE is called by template-logic after user has changed the
+  /*/ NODE_TYPES_UPDATE is called by templateEditor-logic after user has changed the
       node type options.  This maps changed options to a new name,
       and deleted type options to existing options.
       This updates:
@@ -614,7 +614,7 @@ MOD.Hook("INITIALIZE", () => {
     UDATA.SetAppState("NCDATA", NCDATA);
   });
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - inside hook
-  /*/ EDGE_TYPES_UPDATE is called by template-logic after user has changed the
+  /*/ EDGE_TYPES_UPDATE is called by templateEditor-logic after user has changed the
       edge type options.  This maps changed options to a new name,
       and deleted type options to existing options.
       This updates:

--- a/build/app/view/netcreate/template-schema.js
+++ b/build/app/view/netcreate/template-schema.js
@@ -201,6 +201,36 @@ MOD.TEMPLATE = {
       description: 'Allow any logged in user to import data.  Admins can always import data.',
       default: false
     },
+    "filterFade": {
+      type: 'string',
+      description: 'Display name of the filter that shows matching items and fades others.',
+      default: 'Fade'
+    },
+    "filterFadeHelp": {
+      type: 'string',
+      description: 'Help text for the Fade filter, displayed on the VIEWS panel.',
+      default: 'Show matches, Fade others'
+    },
+    "filterReduce": {
+      type: 'string',
+      description: 'Display name of the filter that shows matching items and reduces (removes) others.',
+      default: 'Reduce'
+    },
+    "filterReduceHelp": {
+      type: 'string',
+      description: 'Help text for the Reduce filter, displayed on the VIEWS panel.',
+      default: 'Show matches, Reduce (remove) others & recalculate sizes'
+    },
+    "filterFocus": {
+      type: 'string',
+      description: 'Display name of the filter that shows nodes connected to a selected node within a specified range.',
+      default: 'Focus'
+    },
+    "filterFocusHelp": {
+      type: 'string',
+      description: 'Help text for the Focus filter, displayed on the VIEWS panel.',
+      default: 'Show only nodes connected to the selected node within range'
+    },
     "duplicateWarning": {
       type: 'string',
       description: 'Warning message to display if user is trying to create a node that already exists.',

--- a/build/app/view/netcreate/template-schema.js
+++ b/build/app/view/netcreate/template-schema.js
@@ -8,7 +8,7 @@
   the json-editor needs to support and provides meta data about how to
   display and handle the edits.
 
-  `template-logic.js` handles initialization client-side.
+  `templateEditor-logic.js` handles initialization client-side.
 
   NOTE: This schema is NOT the same as the `toml` template file schema.  This
   schema is used by `json-editor` to know how to display a UI for editing the

--- a/build/app/view/netcreate/templateEditor-logic.js
+++ b/build/app/view/netcreate/templateEditor-logic.js
@@ -72,9 +72,66 @@ MOD.ValidateTOMLFile = async data => {
     const json = TOML.parse(tomlText);
     const isValid = true;
     return {isValid, templateJSON: json};
-  }
-  catch (err) {
+  } catch (err) {
     return { isValid: false, error: err };
+  }
+}
+
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/ Validate Template File
+/*/
+// eslint-disable-next-line complexity
+MOD.ValidateTemplate = template => {
+  try {
+    // nodeDefs
+    let nodeDefs = template.nodeDefs;
+    if (nodeDefs === undefined) {
+      throw "Missing `nodeDefs` nodeDefs=" + nodeDefs;
+    }
+    if (nodeDefs.label === undefined) throw "Missing `nodeDefs.label` label=" + nodeDefs.label;
+    if (nodeDefs.type === undefined) throw "Missing `nodeDefs.type` type= " + nodeDefs.type;
+    if (
+      nodeDefs.type.options === undefined ||
+      !Array.isArray(nodeDefs.type.options)
+    ) {
+      throw "Missing or bad `nodeDefs.type.options` options=" +
+        nodeDefs.type.options;
+    }
+    if (nodeDefs.notes === undefined) throw "Missing `nodeDefs.notes` notes=" + nodeDefs.notes;
+    if (nodeDefs.info === undefined) throw "Missing `nodeDefs.info` info=" + nodeDefs.info;
+    // Version 2.x Fields
+    if (nodeDefs.provenance === undefined) throw "Missing `nodeDefs.provenance` provenance=" + nodeDefs.provenance;
+    if (nodeDefs.comments === undefined) throw "Missing `nodeDefs.comments` comments=" + nodeDefs.comments;
+
+    // edgeDefs
+    let edgeDefs = template.edgeDefs;
+    if (edgeDefs === undefined) throw "Missing `edgeDefs` edgeDefs=" + edgeDefs;
+    if (edgeDefs.source === undefined) throw "Missing `edgeDefs.source` source=" + edgeDefs.source;
+    if (edgeDefs.type === undefined) throw "Missing `edgeDefs.type` type= " + edgeDefs.type;
+    if (
+      edgeDefs.type.options === undefined ||
+      !Array.isArray(edgeDefs.type.options)
+    ) {
+      throw "Missing or bad `edgeDefs.type.options` options=" +
+        edgeDefs.type.options;
+    }
+    if (edgeDefs.target === undefined) throw "Missing `edgeDefs.target` label=" + edgeDefs.target;
+    if (edgeDefs.notes === undefined) throw "Missing `edgeDefs.notes` notes=" + edgeDefs.notes;
+    if (edgeDefs.info === undefined) throw "Missing `edgeDefs.info` info=" + edgeDefs.info;
+    // Version 2.x Fields
+    if (edgeDefs.provenance === undefined) throw "Missing `edgeDefs.provenance` provenance=" + edgeDefs.provenance;
+    if (edgeDefs.comments === undefined) throw "Missing `edgeDefs.comments` comments=" + edgeDefs.comments;
+    // -- End 2.x
+    if (edgeDefs.citation === undefined) throw "Missing `edgeDefs.citation` info=" + edgeDefs.citation;
+    if (edgeDefs.category === undefined) throw "Missing `edgeDefs.category` info=" + edgeDefs.category;
+  } catch (error) {
+    const templateFileName = DATASTORE.GetTemplateTOMLFileName();
+    console.error(
+      "Error loading template `",
+      templateFileName,
+      "`::::",
+      error
+    );
   }
 }
 

--- a/build/app/view/netcreate/templateEditor-logic.js
+++ b/build/app/view/netcreate/templateEditor-logic.js
@@ -77,64 +77,6 @@ MOD.ValidateTOMLFile = async data => {
   }
 }
 
-/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/*/ Validate Template File
-/*/
-// eslint-disable-next-line complexity
-MOD.ValidateTemplate = template => {
-  try {
-    // nodeDefs
-    let nodeDefs = template.nodeDefs;
-    if (nodeDefs === undefined) {
-      throw "Missing `nodeDefs` nodeDefs=" + nodeDefs;
-    }
-    if (nodeDefs.label === undefined) throw "Missing `nodeDefs.label` label=" + nodeDefs.label;
-    if (nodeDefs.type === undefined) throw "Missing `nodeDefs.type` type= " + nodeDefs.type;
-    if (
-      nodeDefs.type.options === undefined ||
-      !Array.isArray(nodeDefs.type.options)
-    ) {
-      throw "Missing or bad `nodeDefs.type.options` options=" +
-        nodeDefs.type.options;
-    }
-    if (nodeDefs.notes === undefined) throw "Missing `nodeDefs.notes` notes=" + nodeDefs.notes;
-    if (nodeDefs.info === undefined) throw "Missing `nodeDefs.info` info=" + nodeDefs.info;
-    // Version 2.x Fields
-    if (nodeDefs.provenance === undefined) throw "Missing `nodeDefs.provenance` provenance=" + nodeDefs.provenance;
-    if (nodeDefs.comments === undefined) throw "Missing `nodeDefs.comments` comments=" + nodeDefs.comments;
-
-    // edgeDefs
-    let edgeDefs = template.edgeDefs;
-    if (edgeDefs === undefined) throw "Missing `edgeDefs` edgeDefs=" + edgeDefs;
-    if (edgeDefs.source === undefined) throw "Missing `edgeDefs.source` source=" + edgeDefs.source;
-    if (edgeDefs.type === undefined) throw "Missing `edgeDefs.type` type= " + edgeDefs.type;
-    if (
-      edgeDefs.type.options === undefined ||
-      !Array.isArray(edgeDefs.type.options)
-    ) {
-      throw "Missing or bad `edgeDefs.type.options` options=" +
-        edgeDefs.type.options;
-    }
-    if (edgeDefs.target === undefined) throw "Missing `edgeDefs.target` label=" + edgeDefs.target;
-    if (edgeDefs.notes === undefined) throw "Missing `edgeDefs.notes` notes=" + edgeDefs.notes;
-    if (edgeDefs.info === undefined) throw "Missing `edgeDefs.info` info=" + edgeDefs.info;
-    // Version 2.x Fields
-    if (edgeDefs.provenance === undefined) throw "Missing `edgeDefs.provenance` provenance=" + edgeDefs.provenance;
-    if (edgeDefs.comments === undefined) throw "Missing `edgeDefs.comments` comments=" + edgeDefs.comments;
-    // -- End 2.x
-    if (edgeDefs.citation === undefined) throw "Missing `edgeDefs.citation` info=" + edgeDefs.citation;
-    if (edgeDefs.category === undefined) throw "Missing `edgeDefs.category` info=" + edgeDefs.category;
-  } catch (error) {
-    const templateFileName = DATASTORE.GetTemplateTOMLFileName();
-    console.error(
-      "Error loading template `",
-      templateFileName,
-      "`::::",
-      error
-    );
-  }
-}
-
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/ Update TEMPLATE AppState
     Called by Template.jsx to update the template data with the info from the form.


### PR DESCRIPTION
Addresses #276 

The Filter labels for "Fade", "Remove", and "Focus" functions, along with their accompanying help text, can now be defined via a project template.

The fields that can be edited are:

* filterFade
* filterReduce
* filterFocus
* filterFadeHelp
* filterReduceHelp
* filterFocusHelp


Other Notes
* If an older template does not define these values, default values are drawn from `FilterEnums.js`
* The default values will not be saved to the older template file unless the user explicitly saves the template.  (If it is not saved, it will be automatically converted each time the project opens).

#### Developer Notes

* Template Migration -- Template migration is now an explicit function in `server-database.js`.  Any future changes to `template-schema.js` should also add migration methods here.
* Template loading is now asynchronous -- Template loading should have been asynchronous from the start, but we were able to gloss over it.  However, asynchronous support is needed for migration and validation.