### PR TITLE
Feature: Set max node and edge sizes via template

### DIFF
--- a/build/app/unisys/server-database.js
+++ b/build/app/unisys/server-database.js
@@ -409,6 +409,12 @@ function m_MigrateTemplate() {
   if (TEMPLATE.filterFadeHelp === undefined) TEMPLATE.filterFadeHelp = FILTER.ACTION.HELP.FADE;
   if (TEMPLATE.filterReduceHelp === undefined) TEMPLATE.filterReduceHelp = FILTER.ACTION.HELP.REDUCE;
   if (TEMPLATE.filterFocusHelp === undefined) TEMPLATE.filterFocusHelp = FILTER.ACTION.HELP.FOCUS;
+  // 2023-0605 Max Sizes
+  // See branch `dev-bl/max-size
+  if (TEMPLATE.nodeSizeDefault === undefined) TEMPLATE.nodeSizeDefault = TEMPLATE_SCHEMA.TEMPLATE.properties.nodeSizeDefault.default;
+  if (TEMPLATE.nodeSizeMax === undefined) TEMPLATE.nodeSizeMax = TEMPLATE_SCHEMA.TEMPLATE.properties.nodeSizeMax.default;
+  if (TEMPLATE.edgeSizeDefault === undefined) TEMPLATE.edgeSizeDefault = TEMPLATE_SCHEMA.TEMPLATE.properties.edgeSizeDefault.default;
+  if (TEMPLATE.edgeSizeMax === undefined) TEMPLATE.edgeSizeMax = TEMPLATE_SCHEMA.TEMPLATE.properties.edgeSizeMax.default;
 }
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/build/app/unisys/server-database.js
+++ b/build/app/unisys/server-database.js
@@ -402,13 +402,13 @@ async function m_LoadTemplate() {
 /*/
 function m_MigrateTemplate() {
   // 2023-0602 Filter Labels
-  // See branch `template-filter-labels`, and fb28fa68ee42deffc778c1be013acea7dae85258
-  if (TEMPLATE.filterFade === undefined) TEMPLATE.filterFade = FILTER.ACTION.FADE;
-  if (TEMPLATE.filterReduce === undefined) TEMPLATE.filterReduce = FILTER.ACTION.REDUCE;
-  if (TEMPLATE.filterFocus === undefined) TEMPLATE.filterFocus = FILTER.ACTION.FOCUS;
-  if (TEMPLATE.filterFadeHelp === undefined) TEMPLATE.filterFadeHelp = FILTER.ACTION.HELP.FADE;
-  if (TEMPLATE.filterReduceHelp === undefined) TEMPLATE.filterReduceHelp = FILTER.ACTION.HELP.REDUCE;
-  if (TEMPLATE.filterFocusHelp === undefined) TEMPLATE.filterFocusHelp = FILTER.ACTION.HELP.FOCUS;
+  // See branch `dev-bl/template-filter-labels`, and fb28fa68ee42deffc778c1be013acea7dae85258
+  if (TEMPLATE.filterFade === undefined) TEMPLATE.filterFade = TEMPLATE_SCHEMA.TEMPLATE.properties.filterFade.default;
+  if (TEMPLATE.filterReduce === undefined) TEMPLATE.filterReduce = TEMPLATE_SCHEMA.TEMPLATE.properties.filterReduce.default;
+  if (TEMPLATE.filterFocus === undefined) TEMPLATE.filterFocus = TEMPLATE_SCHEMA.TEMPLATE.properties.filterFocus.default;
+  if (TEMPLATE.filterFadeHelp === undefined) TEMPLATE.filterFadeHelp = TEMPLATE_SCHEMA.TEMPLATE.properties.filterFadeHelp.default;
+  if (TEMPLATE.filterReduceHelp === undefined) TEMPLATE.filterReduceHelp = TEMPLATE_SCHEMA.TEMPLATE.properties.filterReduceHelp.default;
+  if (TEMPLATE.filterFocusHelp === undefined) TEMPLATE.filterFocusHelp = TEMPLATE_SCHEMA.TEMPLATE.properties.filterFocusHelp.default;
   // 2023-0605 Max Sizes
   // See branch `dev-bl/max-size
   if (TEMPLATE.nodeSizeDefault === undefined) TEMPLATE.nodeSizeDefault = TEMPLATE_SCHEMA.TEMPLATE.properties.nodeSizeDefault.default;
@@ -419,6 +419,8 @@ function m_MigrateTemplate() {
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/ Validate Template File
+    This mostly makes sure that nodes and edges have the properties that the UI expects.
+    If a property is missing, we merely throw an error.  We don't do any error recovery.
 /*/
 // eslint-disable-next-line complexity
 function m_ValidateTemplate() {

--- a/build/app/view/netcreate/components/d3-simplenetgraph.js
+++ b/build/app/view/netcreate/components/d3-simplenetgraph.js
@@ -187,10 +187,13 @@ class D3NetGraph {
       // contents of this class+module instance
       this._HandleFilteredD3DataUpdate = this._HandleFilteredD3DataUpdate.bind(this);
       this._HandleTemplateUpdate = this._HandleTemplateUpdate.bind(this);
+      this._ClearSVG = this._ClearSVG.bind(this);
       this._SetDefaultValues = this._SetDefaultValues.bind(this);
       this._SetData           = this._SetData.bind(this);
       this._Initialize        = this._Initialize.bind(this);
       this._UpdateGraph       = this._UpdateGraph.bind(this);
+      this.tooltipForNode = this.tooltipForNode.bind(this);
+      this.displayUpdated = this.displayUpdated.bind(this);
       this._UpdateForces      = this._UpdateForces.bind(this);
       this._Tick              = this._Tick.bind(this);
       this._UpdateLinkStrokeWidth = this._UpdateLinkStrokeWidth.bind(this);
@@ -201,6 +204,7 @@ class D3NetGraph {
       this._ZoomOut = this._ZoomOut.bind(this);
       this._ZoomPanReset = this._ZoomPanReset.bind(this);
       this._HandleZoom        = this._HandleZoom.bind(this);
+      this._Transition = this._Transition.bind(this);
       this._Dragstarted       = this._Dragstarted.bind(this);
       this._Dragged           = this._Dragged.bind(this);
       this._Dragended         = this._Dragended.bind(this);

--- a/build/app/view/netcreate/components/d3-simplenetgraph.js
+++ b/build/app/view/netcreate/components/d3-simplenetgraph.js
@@ -309,7 +309,7 @@ class D3NetGraph {
 
       // updates ignored until this is run restarts the simulation
       // (important if simulation has already slowed down)
-      this.simulation.alpha(.3).restart()  // was 1 - JD
+      this.simulation.alpha(0.3).restart()  // was 1 - JD
     }
   }
 
@@ -568,38 +568,26 @@ class D3NetGraph {
     }
 
 // added by Joshua to generate the text, based on the template, for the tooltip on the node
-tooltipForNode(d)
-{
-    let titleText =  "";
-    if(this.nodeDefs.label.includeInGraphTooltip != undefined)
-    {
-        // Add Label
-          if(this.nodeDefs.label.includeInGraphTooltip)
-            titleText += this.nodeDefs.label.displayLabel + ": " + d.label + "\n";
-        // Add type
-          if (this.nodeDefs.type.includeInGraphTooltip)
-            titleText += this.nodeDefs.type.displayLabel + ": " + d.type + "\n";
-        // Add degrees
-          if(this.nodeDefs.degrees.includeInGraphTooltip)
-            titleText += this.nodeDefs.degrees.displayLabel + ": " + d.degrees + "\n";
-        // Add notes
-          if(this.nodeDefs.notes.includeInGraphTooltip)
-            titleText += this.nodeDefs.notes.displayLabel + ": " + d.notes + "\n";
-        // Add info
-          if(this.nodeDefs.info.includeInGraphTooltip)
-            titleText += this.nodeDefs.info.displayLabel + ": " + d.info + "\n";
-        // Add updated info
-          if(this.nodeDefs.updated.includeInGraphTooltip)
-            titleText += this.nodeDefs.updated.displayLabel + ": " + this.displayUpdated(d);
-    }
-    else
-    {
-
-       // For backwards compatability
-       titleText += this.nodeDefs.displayLabel.label + ": " + d.label + "\n";
-
-    }
-    return titleText;
+tooltipForNode(d) {
+  let titleText =  "";
+  if (this.nodeDefs.label.includeInGraphTooltip !== undefined) {
+    // Add Label
+    if (this.nodeDefs.label.includeInGraphTooltip) titleText += this.nodeDefs.label.displayLabel + ": " + d.label + "\n";
+    // Add type
+    if (this.nodeDefs.type.includeInGraphTooltip) titleText += this.nodeDefs.type.displayLabel + ": " + d.type + "\n";
+    // Add degrees
+    if (this.nodeDefs.degrees.includeInGraphTooltip) titleText += this.nodeDefs.degrees.displayLabel + ": " + d.degrees + "\n";
+    // Add notes
+    if (this.nodeDefs.notes.includeInGraphTooltip) titleText += this.nodeDefs.notes.displayLabel + ": " + d.notes + "\n";
+    // Add info
+    if (this.nodeDefs.info.includeInGraphTooltip) titleText += this.nodeDefs.info.displayLabel + ": " + d.info + "\n";
+    // Add updated info
+    if (this.nodeDefs.updated.includeInGraphTooltip)  titleText += this.nodeDefs.updated.displayLabel + ": " + this.displayUpdated(d);
+  } else {
+    // For backwards compatability
+    titleText += this.nodeDefs.displayLabel.label + ": " + d.label + "\n";
+  }
+  return titleText;
 }
 
 displayUpdated(nodeEdge) {

--- a/build/app/view/netcreate/components/d3-simplenetgraph.js
+++ b/build/app/view/netcreate/components/d3-simplenetgraph.js
@@ -127,7 +127,10 @@ class D3NetGraph {
 
       this.clickFn      = {};
 
-      this.defaultSize  = 5;
+      this.nodeSizeDefault = 5;
+      this.nodeSizeMax = 50;
+      this.edgeSizeDefault = 0.175;
+      this.edgeSizeMax = 50;
 
       // To handled tooltips
       this.nodeDefs = nodeDefs;
@@ -186,6 +189,8 @@ class D3NetGraph {
       this._UpdateGraph       = this._UpdateGraph.bind(this);
       this._UpdateForces      = this._UpdateForces.bind(this);
       this._Tick              = this._Tick.bind(this);
+      this._UpdateLinkStrokeWidth = this._UpdateLinkStrokeWidth.bind(this);
+      this._UpdateLinkStrokeColor = this._UpdateLinkStrokeColor.bind(this);
       this._ColorMap = this._ColorMap.bind(this);
       this._ZoomReset = this._ZoomReset.bind(this);
       this._ZoomIn = this._ZoomIn.bind(this);
@@ -366,7 +371,7 @@ class D3NetGraph {
         .append("circle")
         // "r" has to be set here or circles don't draw.
         .attr("r", (d) => {
-          return this.defaultSize + d.degrees;
+          return Math.min(this.nodeSizeDefault + d.degrees, this.nodeSizeMax);
         })
         //        .attr("r", (d) => { return this.defaultSize }) // d.size ?  d.size/10 : this.defaultSize; })
         .attr("fill", (d) => {
@@ -388,7 +393,7 @@ class D3NetGraph {
         .append("text")
           .classed('noselect', true)
           .attr("font-size", 10)
-          .attr("dx", (d=>{return this.defaultSize + 5})) // 8)
+          .attr("dx", (d=>{return this.nodeSizeDefault + 5})) // 8)
           .attr("dy", "0.35em") // ".15em")
           .text((d) => { return d.label })
           .style("opacity", d => {
@@ -457,7 +462,7 @@ class D3NetGraph {
           })
           .attr("r", (d) => {
             // this "r" is necessary to resize after a link is added
-            return this.defaultSize + d.degrees;
+            return Math.min(this.nodeSizeDefault + d.degrees, this.nodeSizeMax);
           })
           .transition()
           .duration(500)
@@ -593,14 +598,14 @@ displayUpdated(nodeEdge) {
             .iterations(M_FORCEPROPERTIES.link.iterations))
         .force("charge", d3.forceManyBody()
             // the larger the node, the harder it pushes
-            .strength(d => (this.defaultSize+d.degrees) * M_FORCEPROPERTIES.charge.strength * M_FORCEPROPERTIES.charge.enabled )
+            .strength(d => (this.nodeSizeDefault+d.degrees) * M_FORCEPROPERTIES.charge.strength * M_FORCEPROPERTIES.charge.enabled )
             .distanceMin(M_FORCEPROPERTIES.charge.distanceMin)
             .distanceMax(M_FORCEPROPERTIES.charge.distanceMax))
         .force("collide", d3.forceCollide()
             .strength(M_FORCEPROPERTIES.collide.strength * M_FORCEPROPERTIES.collide.enabled)
             // node radius (defaultSize+degrees) + preset radius keeps nodes separated
             // from each other like bouncing balls
-            .radius(d => this.defaultSize+d.degrees+M_FORCEPROPERTIES.collide.radius)
+            .radius(d => this.nodeSizeDefault+d.degrees+M_FORCEPROPERTIES.collide.radius)
             .iterations(M_FORCEPROPERTIES.collide.iterations))
         .force("center", d3.forceCenter()
             .x(m_width * M_FORCEPROPERTIES.center.x)
@@ -650,9 +655,9 @@ _UpdateLinkStrokeWidth(edge) {
     (sourceId === mouseoverNodeId) ||
     (targetId === mouseoverNodeId)
   ) {
-    return edge.size ** 2;  // Use **2 to make size differences more noticeable
+    return Math.min(edge.size ** 2, this.edgeSizeMax);  // Use **2 to make size differences more noticeable
   } else {
-    return 0.175;             // Barely visible if not selected
+    return this.edgeSizeDefault;             // Barely visible if not selected
   }
 }
 

--- a/build/app/view/netcreate/components/d3-simplenetgraph.js
+++ b/build/app/view/netcreate/components/d3-simplenetgraph.js
@@ -127,10 +127,10 @@ class D3NetGraph {
 
       this.clickFn      = {};
 
-      this.nodeSizeDefault = 5;
-      this.nodeSizeMax = 50;
-      this.edgeSizeDefault = 0.175;
-      this.edgeSizeMax = 50;
+      this.nodeSizeDefault = 5; // overriden by template
+      this.nodeSizeMax = 50; // overriden by template
+      this.edgeSizeDefault = 0.175; // overriden by template
+      this.edgeSizeMax = 50; // overriden by template
 
       // To handled tooltips
       this.nodeDefs = nodeDefs;
@@ -142,6 +142,8 @@ class D3NetGraph {
   /// D3 CODE ///////////////////////////////////////////////////////////////////
   /// note: this is all inside the class constructor function!
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+      this._SetDefaultValues();
 
       // Set up Zoom
       this.zoom = d3.zoom().on("zoom", this._HandleZoom);
@@ -184,6 +186,8 @@ class D3NetGraph {
       // bind 'this' to function objects so event handlers can access
       // contents of this class+module instance
       this._HandleFilteredD3DataUpdate = this._HandleFilteredD3DataUpdate.bind(this);
+      this._HandleTemplateUpdate = this._HandleTemplateUpdate.bind(this);
+      this._SetDefaultValues = this._SetDefaultValues.bind(this);
       this._SetData           = this._SetData.bind(this);
       this._Initialize        = this._Initialize.bind(this);
       this._UpdateGraph       = this._UpdateGraph.bind(this);
@@ -212,6 +216,7 @@ class D3NetGraph {
       // });
 
       UDATA.OnAppStateChange('FILTEREDD3DATA', this._HandleFilteredD3DataUpdate);
+      UDATA.OnAppStateChange('TEMPLATE', this._HandleTemplateUpdate);
       UDATA.OnAppStateChange('COLORMAP', this._ColorMap);
       UDATA.HandleMessage('ZOOM_RESET', this._ZoomReset);
       UDATA.HandleMessage('ZOOM_IN', this._ZoomIn);
@@ -251,6 +256,13 @@ class D3NetGraph {
     this._SetData(data);
   }
 
+  /*/ Update default values when template has changed
+  /*/
+  _HandleTemplateUpdate(data) {
+    if (DBG) console.log(PR, 'got state TEMPLATE', data);
+    this._SetDefaultValues();
+  }
+
 /*/ Clear the SVG data
     Currently not used because we just deconstruct d3-simplenetgraph insead.
     Was thought to be needed during imports otherwise _UpdateGraph reads data from existing
@@ -261,6 +273,16 @@ class D3NetGraph {
     this.zoomWrapper.selectAll(".node").remove();
   }
 
+
+  /*/ Set default node and edge size values from TEMPLATE
+  /*/
+  _SetDefaultValues() {
+    const TEMPLATE = UDATA.AppState("TEMPLATE");
+    this.nodeSizeDefault = TEMPLATE.nodeSizeDefault;
+    this.nodeSizeMax = TEMPLATE.nodeSizeMax;
+    this.edgeSizeDefault = TEMPLATE.edgeSizeDefault;
+    this.edgeSizeMax = TEMPLATE.edgeSizeMax;
+  }
 
 /*/ The parent container passes data to the d3 graph via this SetData call
     which then triggers all the internal updates

--- a/build/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/build/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -74,7 +74,7 @@ class FiltersPanel extends UNISYS.Component {
   LookupFilterHelp(filterAction) {
     const TEMPLATE = UDATA.AppState("TEMPLATE");
     if (filterAction === FILTER.ACTION.FADE) return TEMPLATE.filterFadeHelp;
-    if (filterAction === FILTER.ACTION.FILTER) return FILTER.ACTION.HELP.FILTER; // FIX: Remove this once we decide we don't want to support Filter/hide
+    //if (filterAction === FILTER.ACTION.FILTER) return FILTER.ACTION.HELP.FILTER; // FIX: Remove this once we decide we don't want to support Filter/hide
     if (filterAction === FILTER.ACTION.REDUCE) return TEMPLATE.filterReduceHelp;
     if (filterAction === FILTER.ACTION.FOCUS) return TEMPLATE.filterFocusHelp;
     return "Help not found";

--- a/build/app/view/netcreate/template-schema.js
+++ b/build/app/view/netcreate/template-schema.js
@@ -141,6 +141,8 @@ MOD.EDGETYPEOPTIONS = {
 /*/ Main NetCreate Schema Template
     This references the NODETYPEOPTIONS and EGETYPEOPTIONS above to define
     options.
+    Be sure to update `server-database.m_MigrateTemplate()` with any additions to
+    the schema to maintain backward compatibility.
 /*/
 MOD.TEMPLATE = {
   title: 'NetCreate Template',
@@ -200,6 +202,26 @@ MOD.TEMPLATE = {
       format: 'checkbox',
       description: 'Allow any logged in user to import data.  Admins can always import data.',
       default: false
+    },
+    "nodeSizeDefault": {
+      type: 'number',
+      description: 'Default size (radius) of nodes.',
+      default: 5
+    },
+    "nodeSizeMax": {
+      type: 'number',
+      description: 'Maximum size (radius) of nodes.',
+      default: 50
+    },
+    "edgeSizeDefault": {
+      type: 'number',
+      description: 'Default size (width) of edges (barely visible).',
+      default: 0.175
+    },
+    "edgeSizeMax": {
+      type: 'number',
+      description: 'Maximum size (width) of edges.',
+      default: 10
     },
     "filterFade": {
       type: 'string',

--- a/build/app/view/netcreate/template-schema.js
+++ b/build/app/view/netcreate/template-schema.js
@@ -221,7 +221,7 @@ MOD.TEMPLATE = {
     "edgeSizeMax": {
       type: 'number',
       description: 'Maximum size (width) of edges.',
-      default: 10
+      default: 25
     },
     "filterFade": {
       type: 'string',


### PR DESCRIPTION
Addresses netcreateorg/netcreate-2018#246 

This adds four parameters to the template:
* `nodeSizeDefault` -- default: 5 -- radius
* `nodeSizeMax` -- default: 50 -- radius
* `edgeSizeDefault` -- default: 0.175 -- stroke width
* `edgeSizeMax` -- default: 25 -- stroke width

And also implements the max size limit during drawing with `d3-simplenetgraph`.

A few notes:

* Generally you probably want `edgeSizeMax` to be no greater than `nodesizeMax * 2` so the link line isn't wider than the node, though it can still be wider than smaller nodes.
* `d3-simplenetgraph` was missing a bunch of `this` binds, which was probably resulting in `undefined` objects.  Ini particularly it's worth checking the functionality of the following to see what changes, if any, were found:
   * `_ClearSVG`
   * `tooltipForNode`
   * `displayUpdated`
   * `_Transition`