### PR TITLE
Feature: Edge Weights

### DIFF
--- a/build/app/unisys/server-database.js
+++ b/build/app/unisys/server-database.js
@@ -334,6 +334,8 @@ function m_LoadTOMLTemplate(templateFilePath) {
       // Migrate v1.4 to v2.0
       // v2.0 added `provenance` and `comments` -- so we add the template definitions if the toml template does not already have them
       // hides them by default if they were not previously added
+      // FIXME: There is related migration code in m_MigrateTemplate() that needs to be merged...if possible
+
       const DEFAULT_TEMPLATE = TEMPLATE_SCHEMA.ParseTemplateSchema();
       const NODEDEFS = DEFAULT_TEMPLATE.nodeDefs;
       if (json.nodeDefs.provenance === undefined) {
@@ -352,6 +354,10 @@ function m_LoadTOMLTemplate(templateFilePath) {
       if (json.edgeDefs.comments === undefined) {
         json.edgeDefs.comments = EDGEDEFS.comments;
         json.edgeDefs.comments.hidden = true;
+      }
+      if (json.edgeDefs.weight === undefined) {
+        json.edgeDefs.weight = EDGEDEFS.weight;
+        json.edgeDefs.weight.hidden = true;
       }
       // NOTE: We are not modifying the template permanently, only temporarily inserting definitions so the system can validate
 
@@ -397,8 +403,12 @@ async function m_LoadTemplate() {
 /// REVIEW: Should this be moved to a separate server-template module?
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/ Migrate Template File
-    Updates older templates to the current template-schema specification.
+    Updates older templates to the current template-schema specification by
+    inserting missing properties needed by the UI.
     Any changes to template-schema should be reflected here.
+
+    FIXME: There is code in m_LoadTOMLTemplate() that also does migration that
+    needs to be moved here!
 /*/
 function m_MigrateTemplate() {
   // 2023-0602 Filter Labels
@@ -419,8 +429,9 @@ function m_MigrateTemplate() {
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/ Validate Template File
-    This mostly makes sure that nodes and edges have the properties that the UI expects.
-    If a property is missing, we merely throw an error.  We don't do any error recovery.
+    Lazy check of template object definitions to make sure they are of
+    expected types and values so the UI doesn't choke and die. Throws an error
+    if property is missing.
 /*/
 // eslint-disable-next-line complexity
 function m_ValidateTemplate() {

--- a/build/app/view/netcreate/NetCreate.jsx
+++ b/build/app/view/netcreate/NetCreate.jsx
@@ -53,6 +53,7 @@ const InfoPanel    = require('./components/InfoPanel');
 const FiltersPanel = require('./components/filter/FiltersPanel');
 const NCLOGIC      = require('./nc-logic'); // require to bootstrap data loading
 const FILTERLOGIC  = require('./filter-logic'); // handles filtering functions
+const EDGELOGIC = require('./edge-logic'); // handles edge synthesis
 const FILTER = require('./components/filter/FilterEnums');
 
 /// REACT COMPONENT ///////////////////////////////////////////////////////////

--- a/build/app/view/netcreate/components/EdgeEditor.jsx
+++ b/build/app/view/netcreate/components/EdgeEditor.jsx
@@ -228,6 +228,7 @@ class EdgeEditor extends UNISYS.Component {
           targetId:     '',
           type: '',
           info:         '',
+          weight: '',
           provenance: '',
           comments: '',
           notes:        '',
@@ -292,6 +293,7 @@ class EdgeEditor extends UNISYS.Component {
       this.onRelationshipChange   = this.onRelationshipChange.bind(this);
       this.onNotesChange          = this.onNotesChange.bind(this);
       this.onInfoChange           = this.onInfoChange.bind(this);
+      this.onWeightChange         = this.onWeightChange.bind(this);
       this.onProvenanceChange = this.onProvenanceChange.bind(this);
       this.onCommentsChange = this.onCommentsChange.bind(this);
       this.onCitationChange       = this.onCitationChange.bind(this);
@@ -342,6 +344,7 @@ class EdgeEditor extends UNISYS.Component {
           targetId:     '',
           type: '',
           info:         '',
+          weight: '',
           provenance: '',
           comments: '',
           notes:        '',
@@ -450,6 +453,7 @@ class EdgeEditor extends UNISYS.Component {
           type: '',
           notes: '',
           info: '',
+          weight: '',
           provenance: provenance_str,
           comments: '',
           citation: '',
@@ -501,6 +505,7 @@ class EdgeEditor extends UNISYS.Component {
           targetId:     edge.target,
           type: edge.type || '',   // Make sure there's valid data
           info: edge.info || '',
+          weight: edge.weight || '',
           provenance: edge.provenance || '',
           comments: edge.comments || '',
           citation: edge.citation || '',
@@ -855,10 +860,17 @@ class EdgeEditor extends UNISYS.Component {
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/
 /*/ onInfoChange (event) {
-      let formData = this.state.formData;
-      formData.info = event.target.value;
-      this.setState({formData: formData});
-    }
+  let formData = this.state.formData;
+  formData.info = event.target.value;
+  this.setState({formData: formData});
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/
+/*/ onWeightChange (event) {
+  let formData = this.state.formData;
+  formData.weight = event.target.value;
+  this.setState({formData: formData});
+}
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/
 /*/ onProvenanceChange (event) {
@@ -909,6 +921,7 @@ class EdgeEditor extends UNISYS.Component {
         target:         this.state.targetNode.id,   // REVIEW: d3data 'target' is id, rename this to 'targetId'?
         type: formData.type,
         info: formData.info,
+        weight: formData.weight,
         provenance: formData.provenance,
         comments: formData.comments,
         citation: formData.citation,
@@ -1167,7 +1180,7 @@ class EdgeEditor extends UNISYS.Component {
                 </Col>
               </FormGroup>
               {/** weight **/}
-              <FormGroup row hidden={false /* edgeDefs.weight.hidden */}>
+              <FormGroup row hidden={edgeDefs.weight.hidden}>
                 <Col sm={3} style={{hyphens: 'auto'}} className="pr-0">
                   <Label for="weight" className="tooltipAnchor small text-muted">
                     {"Weight" /*edgeDefs.weight.displayLabel*/}

--- a/build/app/view/netcreate/components/EdgeEditor.jsx
+++ b/build/app/view/netcreate/components/EdgeEditor.jsx
@@ -867,8 +867,12 @@ class EdgeEditor extends UNISYS.Component {
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/
 /*/ onWeightChange (event) {
+  // The built in <input min="0"> will keep the step buttons from going below 0,
+  // but the user can still input "0". When editing, you need to be able to
+  // delete the whole field, so we allow blanks, otherwise the UI will always
+  // force a "0" in the field.
   let formData = this.state.formData;
-  formData.weight = Number(event.target.value); // force Number type
+  formData.weight = event.target.value < 1 ? "" : Number(event.target.value); // force Number type
   this.setState({formData: formData});
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/build/app/view/netcreate/components/EdgeEditor.jsx
+++ b/build/app/view/netcreate/components/EdgeEditor.jsx
@@ -228,7 +228,7 @@ class EdgeEditor extends UNISYS.Component {
           targetId:     '',
           type: '',
           info:         '',
-          weight: '',
+          weight: 1,
           provenance: '',
           comments: '',
           notes:        '',
@@ -344,7 +344,7 @@ class EdgeEditor extends UNISYS.Component {
           targetId:     '',
           type: '',
           info:         '',
-          weight: '',
+          weight: 1,
           provenance: '',
           comments: '',
           notes:        '',
@@ -453,7 +453,7 @@ class EdgeEditor extends UNISYS.Component {
           type: '',
           notes: '',
           info: '',
-          weight: '',
+          weight: 1,
           provenance: provenance_str,
           comments: '',
           citation: '',
@@ -505,7 +505,7 @@ class EdgeEditor extends UNISYS.Component {
           targetId:     edge.target,
           type: edge.type || '',   // Make sure there's valid data
           info: edge.info || '',
-          weight: edge.weight || '',
+          weight: edge.weight || 1,
           provenance: edge.provenance || '',
           comments: edge.comments || '',
           citation: edge.citation || '',
@@ -868,7 +868,7 @@ class EdgeEditor extends UNISYS.Component {
 /*/
 /*/ onWeightChange (event) {
   let formData = this.state.formData;
-  formData.weight = event.target.value;
+  formData.weight = Number(event.target.value); // force Number type
   this.setState({formData: formData});
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/build/app/view/netcreate/components/EdgeEditor.jsx
+++ b/build/app/view/netcreate/components/EdgeEditor.jsx
@@ -1082,6 +1082,7 @@ class EdgeEditor extends UNISYS.Component {
                   <AutoComplete
                     identifier={'edge'+edgeID+'target'}
                     disabledValue={targetNode.label}
+                    // eslint-disable-next-line no-nested-ternary
                     inactiveMode={ ( parentNodeLabel===targetNode.label && !sameSourceAndTarget ) ? 'static' : this.state.isBeingEdited ? 'disabled' : 'link'}
                     linkID={targetNode.id}
                     shouldIgnoreSelection={!this.state.targetIsEditable}
@@ -1165,6 +1166,23 @@ class EdgeEditor extends UNISYS.Component {
                   />
                 </Col>
               </FormGroup>
+              {/** weight **/}
+              <FormGroup row hidden={false /* edgeDefs.weight.hidden */}>
+                <Col sm={3} style={{hyphens: 'auto'}} className="pr-0">
+                  <Label for="weight" className="tooltipAnchor small text-muted">
+                    {"Weight" /*edgeDefs.weight.displayLabel*/}
+                    <span className="tooltiptext">{this.helpText(edgeDefs.weight)}</span>
+                  </Label>
+                </Col>
+                <Col sm={9}>
+                  <Input type="text" name="weight"
+                    value={formData.weight}
+                    onChange={this.onWeightChange}
+                    readOnly={!this.state.isBeingEdited}
+                  />
+                </Col>
+              </FormGroup>
+              {/** provenance **/}
               <FormGroup row hidden={edgeDefs.provenance.hidden}>
                 <Col sm={3} style={{hyphens: 'auto'}} className="pr-0">
                   <Label for="provenance" className="tooltipAnchor small text-muted">

--- a/build/app/view/netcreate/components/EdgeEditor.jsx
+++ b/build/app/view/netcreate/components/EdgeEditor.jsx
@@ -1183,7 +1183,7 @@ class EdgeEditor extends UNISYS.Component {
               <FormGroup row hidden={edgeDefs.weight.hidden}>
                 <Col sm={3} style={{hyphens: 'auto'}} className="pr-0">
                   <Label for="weight" className="tooltipAnchor small text-muted">
-                    {"Weight" /*edgeDefs.weight.displayLabel*/}
+                    {edgeDefs.weight.displayLabel}
                     <span className="tooltiptext">{this.helpText(edgeDefs.weight)}</span>
                   </Label>
                 </Col>

--- a/build/app/view/netcreate/components/EdgeEditor.jsx
+++ b/build/app/view/netcreate/components/EdgeEditor.jsx
@@ -1188,7 +1188,7 @@ class EdgeEditor extends UNISYS.Component {
                   </Label>
                 </Col>
                 <Col sm={9}>
-                  <Input type="text" name="weight"
+                  <Input type="number" name="weight" min="1"
                     value={formData.weight}
                     onChange={this.onWeightChange}
                     readOnly={!this.state.isBeingEdited}

--- a/build/app/view/netcreate/components/EdgeTable.jsx
+++ b/build/app/view/netcreate/components/EdgeTable.jsx
@@ -567,6 +567,9 @@ class EdgeTable extends UNISYS.Component {
                 <th  width="10%"hidden={edgeDefs.info.hidden}><Button size="sm"
                       onClick={()=>this.setSortKey("Info", edgeDefs.info.type)}
                     >{edgeDefs.info.displayLabel} {this.sortSymbol("Info")}</Button></th>
+                <th  width="10%"hidden={edgeDefs.weight.hidden}><Button size="sm"
+                      onClick={()=>this.setSortKey("Weight", edgeDefs.weight.type)}
+                    >{edgeDefs.weight.displayLabel} {this.sortSymbol("Weight")}</Button></th>
                 <th  width="7%"hidden={edgeDefs.provenance.hidden}><Button size="sm"
                       onClick={()=>this.setSortKey("provenance", edgeDefs.provenance.type)}
                     >{edgeDefs.provenance.displayLabel} {this.sortSymbol("provenance")}</Button></th>
@@ -605,6 +608,7 @@ class EdgeTable extends UNISYS.Component {
                   {edge.notes ? <MarkdownNote text={edge.notes} /> : "" }
                 </td>
                 <td hidden={edgeDefs.info.hidden}>{edge.info}</td>
+                <td hidden={edgeDefs.weight.hidden}>{edge.weight}</td>
                 <td hidden={edgeDefs.provenance.hidden}
                   style={{ fontSize: '9px' }}
                 >{edge.provenance}</td>

--- a/build/app/view/netcreate/components/EdgeTable.jsx
+++ b/build/app/view/netcreate/components/EdgeTable.jsx
@@ -571,13 +571,13 @@ class EdgeTable extends UNISYS.Component {
                 <th  width="10%"hidden={edgeDefs.info.hidden}><Button size="sm"
                       onClick={()=>this.setSortKey("Info", edgeDefs.info.type)}
                     >{edgeDefs.info.displayLabel} {this.sortSymbol("Info")}</Button></th>
-                <th  width="10%"hidden={edgeDefs.weight.hidden}><Button size="sm"
+                <th  width="4%"hidden={edgeDefs.weight.hidden}><Button size="sm"
                       onClick={()=>this.setSortKey("Weight", edgeDefs.weight.type)}
                     >{edgeDefs.weight.displayLabel} {this.sortSymbol("Weight")}</Button></th>
                 <th  width="7%"hidden={edgeDefs.provenance.hidden}><Button size="sm"
                       onClick={()=>this.setSortKey("provenance", edgeDefs.provenance.type)}
                     >{edgeDefs.provenance.displayLabel} {this.sortSymbol("provenance")}</Button></th>
-                <th  width="10%"hidden={!isLocalHost}><Button size="sm"
+                <th  width="7%"hidden={!isLocalHost}><Button size="sm"
                       onClick={()=>this.setSortKey("Updated", FILTER.TYPES.STRING)}
                     >Updated {this.sortSymbol("Updated")}</Button></th>
                 <th  width="10%"hidden={edgeDefs.comments.hidden}><Button size="sm"

--- a/build/app/view/netcreate/components/EdgeTable.jsx
+++ b/build/app/view/netcreate/components/EdgeTable.jsx
@@ -314,9 +314,9 @@ class EdgeTable extends UNISYS.Component {
                                  // was changed but the full db wasn't updated
             bkey = b[key] || '';
           } else if (type === FILTER.TYPES.NUMBER) {
-            akey = Number(a[key]); // force number for sorting
-            bkey = Number(b[key]);
-          } else {
+            akey = Number(a[key]||''); // force number for sorting
+            bkey = Number(b[key]||'');
+          } else /* if some other type */ {
             akey = a[key];
             bkey = b[key];
           }
@@ -351,6 +351,7 @@ class EdgeTable extends UNISYS.Component {
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/ If no `sortkey` is passed, the sort will use the existing state.sortkey
 /*/ sortTable ( sortkey=this.state.sortkey, edges, type) {
+
       switch (sortkey) {
         case 'id':
           return this.sortByID(edges);
@@ -363,6 +364,9 @@ class EdgeTable extends UNISYS.Component {
           break;
         case 'Info':
           return this.sortByKey(edges, 'info', type);
+          break;
+        case 'Weight':
+          return this.sortByKey(edges, 'weight', type);
           break;
         case 'provenance':
           return this.sortByKey(edges, 'provenance', type);

--- a/build/app/view/netcreate/components/NodeSelector.css
+++ b/build/app/view/netcreate/components/NodeSelector.css
@@ -19,3 +19,9 @@
   width: 100%;
   background-color: #ffff66;
 }
+
+/* Applies to NodeSelector and EdgeEditor, overrides bootstrap */
+.form-control:focus:invalid, .formcontrol:focus:out-of-range, input:invalid, input:out-of-range {
+  border-color: red;
+  box-shadow: 0 0 0 0.2rem rgba(255, 0, 0, .25);
+}

--- a/build/app/view/netcreate/components/NodeTable.jsx
+++ b/build/app/view/netcreate/components/NodeTable.jsx
@@ -285,9 +285,9 @@ class NodeTable extends UNISYS.Component {
                                  // was changed but the full db wasn't updated
             bkey = b[key] || '';
           } else if (type === FILTER.TYPES.NUMBER) {
-            akey = Number(a[key]); // force number for sorting
-            bkey = Number(b[key]);
-          } else {
+            akey = Number(a[key]||''); // force number for sorting
+            bkey = Number(b[key]||'');
+          } else /* some other type */ {
             akey = a[key];
             bkey = b[key];
           }

--- a/build/app/view/netcreate/components/d3-simplenetgraph.js
+++ b/build/app/view/netcreate/components/d3-simplenetgraph.js
@@ -185,7 +185,7 @@ class D3NetGraph {
 
       // bind 'this' to function objects so event handlers can access
       // contents of this class+module instance
-      this._HandleFilteredD3DataUpdate = this._HandleFilteredD3DataUpdate.bind(this);
+      this._HandleD3DataUpdate = this._HandleD3DataUpdate.bind(this);
       this._HandleTemplateUpdate = this._HandleTemplateUpdate.bind(this);
       this._ClearSVG = this._ClearSVG.bind(this);
       this._SetDefaultValues = this._SetDefaultValues.bind(this);
@@ -219,7 +219,12 @@ class D3NetGraph {
       //   this._SetData(data);
       // });
 
-      UDATA.OnAppStateChange('FILTEREDD3DATA', this._HandleFilteredD3DataUpdate);
+      // V2.0 CHANGE
+      // Ignore FILTEREDD3DATA updates!  Only listen for SYNTHESIZEDD3DATA
+      // which represents simplified edge data (duplicate edges removed) for rendering
+      // UDATA.OnAppStateChange('FILTEREDD3DATA', this._HandleFilteredD3DataUpdate);
+
+      UDATA.OnAppStateChange('SYNTHESIZEDD3DATA', this._HandleD3DataUpdate);
       UDATA.OnAppStateChange('TEMPLATE', this._HandleTemplateUpdate);
       UDATA.OnAppStateChange('COLORMAP', this._ColorMap);
       UDATA.HandleMessage('ZOOM_RESET', this._ZoomReset);
@@ -239,7 +244,7 @@ class D3NetGraph {
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   Deregister() {
     if (DBG) console.log(PR, 'd3-simplenetgraph.DESTRUCT!!!')
-    UDATA.AppStateChangeOff('FILTEREDD3DATA', this._HandleFilteredD3DataUpdate);
+    UDATA.AppStateChangeOff('SYNTHESIZEDD3DATA', this._HandleD3DataUpdate);
     UDATA.AppStateChangeOff('COLORMAP', this._ColorMap);
     UDATA.UnhandleMessage('ZOOM_RESET', this._ZoomReset);
     UDATA.UnhandleMessage('ZOOM_IN', this._ZoomIn);
@@ -255,8 +260,8 @@ class D3NetGraph {
    * @param {array} data.nodes
    * @param {array} data.edges
    */
-  _HandleFilteredD3DataUpdate(data) {
-    if (DBG) console.log(PR, 'got state FILTEREDD3DATA', data);
+  _HandleD3DataUpdate(data) {
+    if (DBG) console.log(PR, 'got state D3DATA', data);
     this._SetData(data);
   }
 
@@ -669,7 +674,10 @@ _UpdateLinkStrokeWidth(edge) {
     (sourceId === mouseoverNodeId) ||
     (targetId === mouseoverNodeId)
   ) {
-    return Math.min(edge.size ** 2, this.edgeSizeMax);  // Use **2 to make size differences more noticeable
+    // max size checking is in edge-logic
+    return edge.size;
+    // return edge.size ** 2;  // Use **2 to make size differences more noticeable
+    // return Math.min(edge.size ** 2, this.edgeSizeMax);  // Use **2 to make size differences more noticeable
   } else {
     return this.edgeSizeDefault;             // Barely visible if not selected
   }

--- a/build/app/view/netcreate/components/d3-simplenetgraph.js
+++ b/build/app/view/netcreate/components/d3-simplenetgraph.js
@@ -683,11 +683,9 @@ _UpdateLinkStrokeWidth(edge) {
   }
 }
 
+/// Edge color is pre-set by edge-logic based on weights
 _UpdateLinkStrokeColor(edge) {
-  if (DBG) console.log(PR, '_UpdateLinkStrokeColor', edge)
-  let COLORMAP = UDATA.AppState('COLORMAP');
-  let color = COLORMAP.edgeColorMap[edge.type]
-  return color;
+  return edge.color;
 }
 
 

--- a/build/app/view/netcreate/edge-logic.js
+++ b/build/app/view/netcreate/edge-logic.js
@@ -1,0 +1,99 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  EDGE LOGIC
+
+  edge-logic handles
+
+  edge-logic takes the incoming FILTEREDD3DATA and simplifies the
+  edges, doing the following:
+    1. Removes any duplicate edges between a source and target
+    2. Caclulates the edge size using the edge.weigth parameter
+    3. Updates the SYNTHESIZEDD3DATA app state
+
+  When SYNTHESIZEDD3DATA is updated, d3-simplenetgraph will redraw.
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+
+/// LIBRARIES /////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const UNISYS = require("unisys/client");
+
+/// INITIALIZE MODULE /////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+var MOD = UNISYS.NewModule(module.id);
+var UDATA = UNISYS.NewDataLink(MOD);
+
+/// CONSTANTS /////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const DBG = false;
+const PR = "edge-logic: ";
+
+/// UNISYS HANDLERS ///////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/ lifecycle INITIALIZE handler
+/*/
+MOD.Hook("INITIALIZE", () => {
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /*/ FILTEREDD3DATA is updated by filter-logic after NCDATA is changed.
+  /*/
+  UDATA.OnAppStateChange("FILTEREDD3DATA", data => {
+    m_SynthesizeEdges(data);
+  })
+
+}); // end UNISYS_INIT
+
+
+/// MODULE METHODS ////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/**
+ * m_SynthesizeEdges uses a Map to reduce duplicate edges into a simple
+ * array, calculating edge size based on edge.weight parameter along the way.
+ * @param {object} data FILTEREDD3DATA e.g. { nodes, edges }
+ */
+function m_SynthesizeEdges(data) {
+  const DEFAULT_SIZE = 1;
+  const SYNTHESIZEDD3DATA = data;
+
+  const TEMPLATE = UDATA.AppState("TEMPLATE");
+  const edgeSizeMax = TEMPLATE.edgeSizeMax;
+
+  /*/ ISSUES
+      * How do we handle direction?
+        => Can be handled with a single edge, we just need to determin directionlaity
+      * How do we handle bidrectionality?  Is it a single edge?
+        => Yes.  Just with two arrowheads.
+  /*/
+
+  // Synthesize duplicate edges into a single edge.
+  const edgeMap = new Map(); // key = {source}{target}
+  SYNTHESIZEDD3DATA.edges.forEach(e => {
+    let skey = e.source;
+    let tkey = e.target;
+    if (e.target < e.source) { // the smaller key is always first
+      skey = e.target;
+      tkey = e.source;
+    }
+    const edgeKey = `${skey},${tkey}`;
+    if (edgeMap.has(edgeKey)) {
+      const currEdge = edgeMap.get(edgeKey);
+      const currSize = currEdge.size;
+      e.size = currSize + (e.weight || DEFAULT_SIZE); // weight defaults to 1
+    } else {
+      e.size = e.weight || DEFAULT_SIZE; // weight defaults to 1
+    }
+    // set max
+    if (edgeSizeMax > 0) e.size = Math.min(edgeSizeMax, e.size);
+    edgeMap.set(edgeKey, e);
+  });
+  SYNTHESIZEDD3DATA.edges = [...edgeMap.values()];
+  UDATA.SetAppState('SYNTHESIZEDD3DATA', SYNTHESIZEDD3DATA);
+}
+
+
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+/// EXPORT CLASS DEFINITION ///////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+module.exports = MOD;

--- a/build/app/view/netcreate/edge-logic.js
+++ b/build/app/view/netcreate/edge-logic.js
@@ -79,9 +79,9 @@ function m_SynthesizeEdges(data) {
     if (edgeMap.has(edgeKey)) {
       const currEdge = edgeMap.get(edgeKey);
       const currSize = currEdge.size;
-      e.size = currSize + (e.weight || DEFAULT_SIZE); // weight defaults to 1
+      e.size = currSize + (Number(e.weight) || DEFAULT_SIZE); // weight defaults to 1, force Number
     } else {
-      e.size = e.weight || DEFAULT_SIZE; // weight defaults to 1
+      e.size = Number(e.weight) || DEFAULT_SIZE; // weight defaults to 1, force Number
     }
     // set max
     if (edgeSizeMax > 0) e.size = Math.min(edgeSizeMax, e.size);

--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -360,6 +360,7 @@ function m_FiltersApply() {
 
   // Update FILTEREDD3DATA
   UDATA.SetAppState("FILTEREDD3DATA", FILTEREDD3DATA);
+  // edge-logic handles this call and updates SYNTHESIZEDD3DATA, which is rendered by d3-simplenetgraph
 
 }
 

--- a/build/app/view/netcreate/template-schema.js
+++ b/build/app/view/netcreate/template-schema.js
@@ -151,7 +151,7 @@ MOD.TEMPLATE = {
     "name": {
       type: 'string',
       description: 'A short descriptive title for the project.  This is displayed on the graph view.  It can contain spaces.  e.g. "Alexander the Great"',
-      default: 'Untitled Template'
+      default: 'Untitled Project'
     },
     "description": {
       type: 'string',
@@ -181,6 +181,7 @@ MOD.TEMPLATE = {
     "requireLogin": {
       type: 'boolean',
       format: 'checkbox',
+      description: 'Users are required to log in to view the graph.',
       default: false
     },
     "hideDeleteNodeButton": {
@@ -215,8 +216,8 @@ MOD.TEMPLATE = {
     },
     "edgeSizeDefault": {
       type: 'number',
-      description: 'Default size (width) of edges (barely visible).',
-      default: 0.175
+      description: 'Default size (width) of edges.',
+      default: 1 // Was 0.175 to be barely visible, but edge weights now override this default to 1
     },
     "edgeSizeMax": {
       type: 'number',
@@ -225,7 +226,7 @@ MOD.TEMPLATE = {
     },
     "filterFade": {
       type: 'string',
-      description: 'Display name of the filter that shows matching items and fades others.',
+      description: 'Display name of the filter function that shows matching items and fades others.',
       default: 'Fade'
     },
     "filterFadeHelp": {
@@ -235,7 +236,7 @@ MOD.TEMPLATE = {
     },
     "filterReduce": {
       type: 'string',
-      description: 'Display name of the filter that shows matching items and reduces (removes) others.',
+      description: 'Display name of the filter function that shows matching items and reduces (removes) others.',
       default: 'Reduce'
     },
     "filterReduceHelp": {
@@ -245,7 +246,7 @@ MOD.TEMPLATE = {
     },
     "filterFocus": {
       type: 'string',
-      description: 'Display name of the filter that shows nodes connected to a selected node within a specified range.',
+      description: 'Display name of the filter fucntion that shows nodes connected to a selected node within a specified range.',
       default: 'Focus'
     },
     "filterFocusHelp": {
@@ -280,23 +281,23 @@ MOD.TEMPLATE = {
     },
     "nodeDefaultTransparency": {
       type: 'number',
-      description: 'Default transparency for nodes.',
+      description: 'Default transparency for nodes (0 - 1).',
       default: 1.0
     },
     "edgeDefaultTransparency": {
       type: 'number',
-      description: 'Default transparency for edges.',
+      description: 'Default transparency for edges (0 - 1.',
       default: 0.7
     },
     "searchColor": {
       type: 'string',
-      description: 'Outline color of nodes selected via search.',
+      description: 'Outline color of nodes selected via search (hex).',
       default: '#008800',
       format: 'color'
     },
     "sourceColor": {
       type: 'string',
-      description: 'Outline color of node highlighted during auto complete.',
+      description: 'Outline color of node highlighted during auto complete (hex).',
       default: '#FFa500',
       format: 'color'
     },
@@ -308,8 +309,7 @@ MOD.TEMPLATE = {
           properties: {
             "type": {
               type: 'number',
-              // not editable
-              options: { hidden: true },
+              options: { hidden: true }, // not editable
               description: '"id" data type',
               default: 'number'
             },
@@ -325,8 +325,7 @@ MOD.TEMPLATE = {
             },
             "help": {
               type: 'string',
-              // not editable
-              options: { hidden: true },
+              options: { hidden: true }, // not editable
               description: 'Help text to display on the Node Editor form',
               default: 'System-generated unique id number'
             },
@@ -351,8 +350,7 @@ MOD.TEMPLATE = {
           properties: {
             "type": {
               type: 'string',
-              // not editable
-              options: { hidden: true },
+              options: { hidden: true }, // not editable
               description: '"label" data type',
               default: 'string'
             },
@@ -392,8 +390,7 @@ MOD.TEMPLATE = {
           properties: {
             "type": {
               type: 'string',
-              // not editable
-              options: { hidden: true },
+              options: { hidden: true }, // not editable
               description: 'node "type" data type',
               default: 'select'
             },
@@ -410,7 +407,7 @@ MOD.TEMPLATE = {
             "help": {
               type: 'string',
               description: 'Help text to display on the Node Editor form',
-              default: 'Multiple people are a "Group"'
+              default: 'Select a category'
             },
             "includeInGraphTooltip": {
               type: 'boolean',
@@ -429,7 +426,7 @@ MOD.TEMPLATE = {
         },
         "notes": { // Significance
           type: 'object',
-          description: 'Display name of the node',
+          description: 'General purpose notes text field',
           properties: {
             "type": {
               type: 'string',
@@ -449,7 +446,7 @@ MOD.TEMPLATE = {
             "help": {
               type: 'string',
               description: 'Help text to display on the Node Editor form',
-              default: 'Display name of the node'
+              default: 'General purpose notes text field'
             },
             "includeInGraphTooltip": {
               type: 'boolean',
@@ -467,7 +464,7 @@ MOD.TEMPLATE = {
         },
         "info": { // Info/Number
           type: 'object',
-          description: 'Display name of the node',
+          description: 'General purpose numeric text field',
           properties: {
             "type": {
               type: 'string',
@@ -505,7 +502,7 @@ MOD.TEMPLATE = {
         },
         "provenance": { // Provenance/Source
           type: 'object',
-          description: 'Display name of the node',
+          description: 'Who created the node',
           properties: {
             "type": {
               type: 'string',
@@ -543,7 +540,7 @@ MOD.TEMPLATE = {
         },
         "comments": { // Comments
           type: 'object',
-          description: 'Display name of the node',
+          description: 'User comments on the node',
           properties: {
             "type": {
               type: 'string',
@@ -581,7 +578,7 @@ MOD.TEMPLATE = {
         },
         "degrees": {
           type: 'object',
-          description: 'Display name of the node',
+          description: 'Number of edges connected to this node (auto-calculated)',
           properties: {
             "type": {
               type: 'string',
@@ -726,8 +723,7 @@ MOD.TEMPLATE = {
           properties: {
             "type": {
               type: 'number',
-              // not editable
-              options: { hidden: true },
+              options: { hidden: true }, // not editable
               description: '"id" data type',
               default: 'number'
             },
@@ -743,9 +739,8 @@ MOD.TEMPLATE = {
             },
             "help": {
               type: 'string',
-              // not editable
-              options: { hidden: true },
-              description: 'Help text to display on the Node Editor form',
+              options: { hidden: true }, // not editable
+              description: 'Help text to display on the Edge Editor form',
               default: 'System-generated unique id number'
             },
             "hidden": {
@@ -759,12 +754,11 @@ MOD.TEMPLATE = {
         },
         "source": {
           type: 'object',
-          description: 'Display name of the node',
+          description: 'Node the edge is connected to',
           properties: {
             "type": {
               type: 'string',
-              // not editable
-              options: { hidden: true },
+              options: { hidden: true }, // not editable
               description: '"source" data type',
               default: 'number'
             },
@@ -794,12 +788,11 @@ MOD.TEMPLATE = {
         },
         "target": {
           type: 'object',
-          description: 'Display name of the node',
+          description: 'Node the edge is connected to',
           properties: {
             "type": {
               type: 'string',
-              // not editable
-              options: { hidden: true },
+              options: { hidden: true }, // not editable
               description: '"target" data type',
               default: 'number'
             },
@@ -833,8 +826,7 @@ MOD.TEMPLATE = {
           properties: {
             "type": {
               type: 'string',
-              // not editable
-              options: { hidden: true },
+              options: { hidden: true }, // not editable
               description: 'edge "type" data type',
               default: 'select'
             },
@@ -864,7 +856,7 @@ MOD.TEMPLATE = {
         },
         "notes": { // Signficance
           type: 'object',
-          description: 'Display name of the node',
+          description: 'General purpose notes text field',
           properties: {
             "type": {
               type: 'string',
@@ -896,7 +888,7 @@ MOD.TEMPLATE = {
         },
         "info": { // Info/Number/Date
           type: 'object',
-          description: 'Display name of the node',
+          description: 'General purpose numeric text field',
           properties: {
             "type": {
               type: 'string',
@@ -964,7 +956,7 @@ MOD.TEMPLATE = {
             "isRequired": {
               type: 'boolean',
               format: 'checkbox',
-              description: 'Make "weight" a required value.  When "true", the default "weight" value will be added to all edges if "weight" was not previously defined.',
+              description: 'Make "weight" a required value.  When "true", "weight" will be set to `defaultValue` for all edges if "weight" was not previously defined.  Be sure to define `defaultValue`',
               default: true
             },
             "hidden": {
@@ -977,7 +969,7 @@ MOD.TEMPLATE = {
         },
         "provenance": { // Provenance/Source
           type: 'object',
-          description: 'Display name of the edge',
+          description: 'Provenance of the edge',
           properties: {
             "type": {
               type: 'string',
@@ -996,20 +988,20 @@ MOD.TEMPLATE = {
             },
             "help": {
               type: 'string',
-              description: 'Help text to display on the Node Editor form',
+              description: 'Help text to display on the Edge Editor form',
               default: 'Who created this?  (aka Provenance)'
             },
             "hidden": {
               type: 'boolean',
               format: 'checkbox',
-              description: 'Hides "provenance" from Node Editor, Nodes Table, and exports',
+              description: 'Hides "provenance" from Edge Editor, Edges Table, and exports',
               default: false
             }
           }
         },
         "comments": { // Comments
           type: 'object',
-          description: 'Display name of the edge',
+          description: 'Comments on the edge',
           properties: {
             "type": {
               type: 'string',
@@ -1047,7 +1039,7 @@ MOD.TEMPLATE = {
         },
         "citation": {
           type: 'object',
-          description: 'Display name of the node',
+          description: 'Source of the edge',
           properties: {
             "type": {
               type: 'string',
@@ -1079,7 +1071,7 @@ MOD.TEMPLATE = {
         },
         "category": {
           type: 'object',
-          description: 'Display name of the node',
+          description: 'General purpose string text field (deprecated)',
           properties: {
             "type": {
               type: 'string',

--- a/build/app/view/netcreate/template-schema.js
+++ b/build/app/view/netcreate/template-schema.js
@@ -220,7 +220,7 @@ MOD.TEMPLATE = {
     },
     "edgeSizeMax": {
       type: 'number',
-      description: 'Maximum size (width) of edges.',
+      description: 'Maximum size (width) of edges.  Set to 0 to turn off maximum size limit.',
       default: 25
     },
     "filterFade": {
@@ -937,7 +937,7 @@ MOD.TEMPLATE = {
             },
             "displayLabel": {
               type: 'string',
-              description: 'Weight of Edgey',
+              description: 'Weight of Edge',
               default: 'Number'
             },
             "exportLabel": {

--- a/build/app/view/netcreate/template-schema.js
+++ b/build/app/view/netcreate/template-schema.js
@@ -937,29 +937,31 @@ MOD.TEMPLATE = {
             },
             "displayLabel": {
               type: 'string',
-              description: 'Weight of Edge',
-              default: 'Number'
+              description: 'Label to use for system display',
+              default: 'Weight'
             },
             "exportLabel": {
               type: 'string',
               description: 'Label to use for exported csv file field name',
-              default: 'Info'
+              default: 'Weight'
             },
             "help": {
               type: 'string',
               description: 'Help text to display on the Edge Editor form',
-              default: 'Some number comparison'
+              default: 'Weight of edge'
             },
             "includeInGraphTooltip": {
               type: 'boolean',
               format: 'checkbox',
-              description: 'Show "info" value in tooltip on graph',
+              description: 'Show "weight" value in tooltip on graph',
+              default: true
+            },
               default: true
             },
             "hidden": {
               type: 'boolean',
               format: 'checkbox',
-              description: 'Hides "info" from Edge Editor, Edes Table, and exports',
+              description: 'Hides "weight" from Edge Editor, Edges Table, and exports',
               default: false
             }
           }

--- a/build/app/view/netcreate/template-schema.js
+++ b/build/app/view/netcreate/template-schema.js
@@ -926,6 +926,44 @@ MOD.TEMPLATE = {
             }
           }
         },
+        "weight": { // Weight/Number
+          type: 'object',
+          description: 'Weight of this edge',
+          properties: {
+            "type": {
+              type: 'number',
+              description: '"weight" data type',
+              default: 'number'
+            },
+            "displayLabel": {
+              type: 'string',
+              description: 'Weight of Edgey',
+              default: 'Number'
+            },
+            "exportLabel": {
+              type: 'string',
+              description: 'Label to use for exported csv file field name',
+              default: 'Info'
+            },
+            "help": {
+              type: 'string',
+              description: 'Help text to display on the Edge Editor form',
+              default: 'Some number comparison'
+            },
+            "includeInGraphTooltip": {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show "info" value in tooltip on graph',
+              default: true
+            },
+            "hidden": {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Hides "info" from Edge Editor, Edes Table, and exports',
+              default: false
+            }
+          }
+        },
         "provenance": { // Provenance/Source
           type: 'object',
           description: 'Display name of the edge',

--- a/build/app/view/netcreate/template-schema.js
+++ b/build/app/view/netcreate/template-schema.js
@@ -935,6 +935,11 @@ MOD.TEMPLATE = {
               description: '"weight" data type',
               default: 'number'
             },
+            "defaultValue": {
+              type: 'number',
+              description: 'The default "weight" of new edges',
+              default: 1
+            },
             "displayLabel": {
               type: 'string',
               description: 'Label to use for system display',
@@ -956,6 +961,10 @@ MOD.TEMPLATE = {
               description: 'Show "weight" value in tooltip on graph',
               default: true
             },
+            "isRequired": {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Make "weight" a required value.  When "true", the default "weight" value will be added to all edges if "weight" was not previously defined.',
               default: true
             },
             "hidden": {


### PR DESCRIPTION
Addresses #245 

This adds a new parameter `weight` to edges.

* By default weight is 1
* Weight can be turned on and off via the template.  Older versions of projects will open with weight defaulting to 1 if there were no values set.
* Maximum edge size is set via the `edgeSizeMax` parameter.  
* `edgeSizeMax` only affects how edges are rendered in d3.  So an edge can have a weight of 100, but if `edgeSizeMax` is 20, it will display only as a 20-pixel wide link.
* Set `edgeSizeMax` to `0` to turn off the max limit.  WARNING: You can potentially end up with lines far wider than the nodes they point to.
* We used to use edge sizes^2 to make the differences between edge sizes more visible.  We removed that for now so that the edgeSize template settings and weight settings are all treated essentially as pixel measurements.  e.g. an edge weight of "2" will have a stroke width of 2 pixels.
* Weight can be viewed in Edge Tables.
* Weight can be filtered.

DEV NOTES:
* We changed the architecture for how d3 renders, adding an edge synthesis module that reduces duplicate edges to a single edge AND at the same time calculates the weight of that edge.  This is a necessary precursor to arrow support as well.
* If you open an older version project, `weight` will be hidden by default.  You'll have to edit the template to unhide `weight` before you'll see when you edit edges.

See also [user input data flow](https://whimsical.com/user-input-data-flow-B2tTGnQYPSNviUhsPL64Dz) whimsical diagram for system architecture.


#### Migrating Data
`server-database.js` will now "migrate" graph data as it opens the project file.  It uses parameters defined in the template to determine if migration is necessary and can automatically define missing fields and set default values.  It currently does not do more sophisticated migration (e.g. change a property from one name to another), but these can be easily added.

Currently this is primarily being used to add the "Weight" to any project that has "Weight" defined as set as "isRequired" and has a `defaultValue` defined.

    The basic check is this:
    1. If the TEMPLATE property `isRequired`
    2. ...and the TEMPLATE propert has `defaultValue` defined
    2. ...and the node/edge property is currently undefined or ``
    3. ...then we set the property to the defaultValue

    The key parameters:
      `property.isRequired`
      `property.defaultValue`

    If `isRequired` or `defaultValue` is not defined on the property, we skip migration..

You can use this technique to auto-populate data on a project.  Just add `isRequired` and `defaultValue` to the projects' `*.template.toml` file.  e.g. this will set all node types to `Person` if the node type was not previously set when the project is opened:

```toml
[nodeDefs.type]
...
isRequired = true
defaultValue = "Person"

[[nodeDefs.type.options]]
color = "#eeeeee"
label = ""
[[nodeDefs.type.options]]
color = "#ff0000"
label = "Person"
```

NOTE the migration does NOT save the changes until you do something to modify the database and trigger an autosave.