### PR TITLE
Bug Fix: Edge transparency is now properly restored after changing filters.

### DIFF
--- a/build/app/view/netcreate/filter-logic.js
+++ b/build/app/view/netcreate/filter-logic.js
@@ -602,14 +602,18 @@ function m_EdgeIsFiltered(edge, filters, transparency, filterAction, FILTEREDD3D
     return e.id === targetId;
   });
 
+  // 0. First set default transparency
+  // restore default transparency, otherwise it could remain faded out
+  edge.filteredTransparency = EDGE_DEFAULT_TRANSPARENCY; // opaque
+
   // 1. If source or target are missing, then remove the edge
-  if (source === undefined || target === undefined ) return false;
+  if (source === undefined || target === undefined) return false;
 
   // 2. If source or target have been removed via collapse or focus, remove the edge
   if (RemovedNodes.includes(source.id) || RemovedNodes.includes(target.id)) return false;
   // 3. if source or target is transparent, then we are transparent too
-  if ( source.filteredTransparency < 1.0 ||
-       target.filteredTransparency < 1.0) {
+  if (source.filteredTransparency < 1.0 ||
+    target.filteredTransparency < 1.0) {
     // regardless of filter definition...
     // ...if filterAction is FILTER
     // always hide edge if it's attached to a filtered node
@@ -642,8 +646,6 @@ function m_EdgeIsFiltered(edge, filters, transparency, filterAction, FILTEREDD3D
   } else if (filterAction === FILTER.ACTION.FADE) {
     if (!keepEdge) {
       edge.filteredTransparency = transparency; // set the transparency value ... right now it is inefficient to set this at the node / edge level, but that's more flexible
-    } else {
-      edge.filteredTransparency = EDGE_DEFAULT_TRANSPARENCY; // opaque
     }
     return true; // always keep in array
   } else if (filterAction === FILTER.ACTION.REDUCE) {

--- a/build/app/view/netcreate/template-schema.js
+++ b/build/app/view/netcreate/template-schema.js
@@ -286,7 +286,7 @@ MOD.TEMPLATE = {
     },
     "edgeDefaultTransparency": {
       type: 'number',
-      description: 'Default transparency for edges (0 - 1.',
+      description: 'Default transparency for edges (0 - 1).',
       default: 0.7
     },
     "searchColor": {


### PR DESCRIPTION
Addresses #296 

Edges that were faded by the "Fade" filter would remain faded when switching filters rather than reverting to the default edge transparency as defined in the Template.  The easiest test:

1. Open a graph with two edge types
2. Select Fade Edge > Type > First Edge Type
3. Select Reduce
4. Select Reduce Edge > Type > Second Edge Type
5. Because the First Edge Type was faded by the Fade filter, they were not being restored to the default transparency.  Now with this fix, the Second Edge Type should be visible.

A side effect of this fix is that edge transparency as defined in the Template is now properly and immediately applied before any filters are activated.  Prior to this we were not applying the template-defined transparency when filters were activated.

See #296 for testing instructions.